### PR TITLE
Remove buggy builds for now

### DIFF
--- a/modules/flake/flake-module.nix
+++ b/modules/flake/flake-module.nix
@@ -74,6 +74,7 @@ in {
           lib.attrsets.mapAttrs (
             _system: packages:
               lib.attrsets.removeAttrs packages [
+                "fortress-disko-vm"
                 "fortress-hyperv"
                 "fortress-install-iso"
                 "fortress-install-iso-hyperv"
@@ -87,7 +88,10 @@ in {
                 "fortress-sd-x86_64"
                 "fortress-vagrant-virtualbox"
                 "fortress-virtualbox"
+                "fortress-vm"
                 "fortress-vmware"
+                "fortress-vm-bootloader"
+                "windex-tarball"
               ]
           )
           self.packages;


### PR DESCRIPTION
Some packages that require qemu-kvm seem to have concurrency issues and crash, etc.