### PR TITLE
Land Dendritic Home Manager foundation

### DIFF
--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -55,6 +55,8 @@ or PATH assumptions. Inherit environment roots only when the tool's state
 contract explicitly requires them.
 Exported environment is an implicit process-tree software bus; publish onto it
 only for an intentional consumer contract, otherwise keep state shell-local.
+Nix-direnv reload is intentionally manual to avoid reload churn; Lorri remains
+an exploratory asynchronous shell-state publisher, not settled bootstrap policy.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,

--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -36,6 +36,11 @@ commit the canonical files, manifest, and regenerated root `AGENTS.md` together.
 A verification mismatch means this proxy is stale: stop and refresh or inspect
 the canonical diff. Never reconstruct intent from the hash itself.
 
+Owner decisions that pivot architecture must be synchronized immediately. Load
+the `decision-sync` route, update every affected canonical statement/ledger/gate,
+refresh and verify the proxy, and commit the bundle. Conversation, goals, and
+model memory are not sufficient durable records.
+
 Current north star: fully and severably land the low-level Home Manager layer,
 push genuinely user-space `nixbook-pro` behavior into it, and prove it with two
 real consumers—nix-darwin-integrated HM and standalone HM—before hardening the

--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -48,6 +48,10 @@ Use `nix run .#agent-checkpoint` as the stable checkpoint entry point. Its name
 is independent of the current Dendritic storage so the mechanics can evolve.
 Bounded checkpoint, propagation, cache verification, and isolated validation
 may be delegated asynchronously when shared-file ownership is non-overlapping.
+For bootstrap tooling, close over immutable logic/tools through Nix, late-bind
+the writable workspace via argument/environment/local discovery, validate it
+before mutation, and preserve a baseline-shell recovery path without devshell
+or PATH assumptions.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,

--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -79,6 +79,8 @@ The frozen predecessor may be deliberately thawed to repair code it still
 owns, then verified, re-pinned, and frozen again. Do not duplicate a capability
 into the bridge merely to carry a repair. This main-based migration line owns
 the sole policy bundle; predecessor-local copies are stale and must be removed.
+Publish frozen/protected branch repairs as final PRs and wait for owner approval
+and merge; move the associated freeze tag only after that approved merge.
 Keep active migration/thaw work in dedicated temporary worktrees until the
 bridge is fully eliminated; remind the owner of this preference before an early
 move into their primary checkout, while allowing an explicit override.

--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -46,6 +46,8 @@ out-of-file-descriptors cache flush or process restart resumes from recent
 committed context rather than conversation memory.
 Use `nix run .#agent-checkpoint` as the stable checkpoint entry point. Its name
 is independent of the current Dendritic storage so the mechanics can evolve.
+Bounded checkpoint, propagation, cache verification, and isolated validation
+may be delegated asynchronously when shared-file ownership is non-overlapping.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,
@@ -73,3 +75,6 @@ The frozen predecessor may be deliberately thawed to repair code it still
 owns, then verified, re-pinned, and frozen again. Do not duplicate a capability
 into the bridge merely to carry a repair. This main-based migration line owns
 the sole policy bundle; predecessor-local copies are stale and must be removed.
+Keep active migration/thaw work in dedicated temporary worktrees until the
+bridge is fully eliminated; remind the owner of this preference before an early
+move into their primary checkout, while allowing an explicit override.

--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -36,6 +36,12 @@ commit the canonical files, manifest, and regenerated root `AGENTS.md` together.
 A verification mismatch means this proxy is stale: stop and refresh or inspect
 the canonical diff. Never reconstruct intent from the hash itself.
 
+Local Codex project-charter caches are mirrors, not an authority. `refresh`
+also updates them. After cloning or pulling on another computer, run
+`.agents/dendritic/context.sh sync-cache` and `verify-cache`. Never leave a
+cache-only architectural mutation: reconcile it into the canonical bundle,
+refresh, verify, commit, and push it for the next machine/model to consume.
+
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,
 refresh and verify the proxy, and commit the bundle. Conversation, goals, and

--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -44,6 +44,8 @@ refresh, verify, commit, and push it for the next machine/model to consume.
 During long sessions, periodically make this canonical checkpoint so an
 out-of-file-descriptors cache flush or process restart resumes from recent
 committed context rather than conversation memory.
+Use `nix run .#agent-checkpoint` as the stable checkpoint entry point. Its name
+is independent of the current Dendritic storage so the mechanics can evolve.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,

--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `b3f950070e885d0531fa6b9b6c7b87e3aa88b5eabcdc41b3a931d426aa73520b`
+Canonical context proxy SHA-256: `@PROXY_SHA256@`
 
 Run:
 

--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -41,6 +41,14 @@ the `decision-sync` route, update every affected canonical statement/ledger/gate
 refresh and verify the proxy, and commit the bundle. Conversation, goals, and
 model memory are not sufficient durable records.
 
+Work as the owner's senior implementation contractor. The owner controls
+requirements and accepted tradeoffs; the agent controls investigation,
+technical execution, and proof. For genuine requirement ambiguity, load
+`collaboration` and ask evidence-backed questions with alternatives,
+consequences, and a recommendation. Load `invariants` before defining public
+capability boundaries. Load `rootfs` whenever owner feedback teaches a durable
+new reasoning or collaboration rule.
+
 Current north star: fully and severably land the low-level Home Manager layer,
 push genuinely user-space `nixbook-pro` behavior into it, and prove it with two
 real consumers—nix-darwin-integrated HM and standalone HM—before hardening the

--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -57,6 +57,14 @@ Exported environment is an implicit process-tree software bus; publish onto it
 only for an intentional consumer contract, otherwise keep state shell-local.
 Nix-direnv reload is intentionally manual to avoid reload churn; Lorri remains
 an exploratory asynchronous shell-state publisher, not settled bootstrap policy.
+Parallel agents own distinct worktrees and branches; verify the remote tip and
+publish with `git push --force-with-lease --atomic`, never to a shared branch.
+Legacy Generic Linux behavior is decision evidence, not automatic parity scope:
+inventory and classify deltas, then require owner retain/redesign/drop decisions.
+Kitty is a backend candidate for a multi-backend terminal interface, not the
+portable interface itself.
+VS Code and VS Code server integration are deferred outside current migration
+scope and are not parity or deletion gates.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,

--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -53,6 +53,8 @@ the writable workspace via explicit argument or local discovery, validate it
 before mutation, and preserve a baseline-shell recovery path without devshell
 or PATH assumptions. Inherit environment roots only when the tool's state
 contract explicitly requires them.
+Exported environment is an implicit process-tree software bus; publish onto it
+only for an intentional consumer contract, otherwise keep state shell-local.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,
@@ -75,6 +77,11 @@ real consumers—nix-darwin-integrated HM and standalone HM—before hardening t
 less-mature high-level interfaces. A coexistence bridge on current `main` is a
 mandatory early deliverable: use it to move the epic to trunk-based incremental
 ports rather than growing another unmergeable Dendritic branch.
+
+Treat flake policy as repository execution policy and terraform the lock graph
+incrementally: use meaningful flake-parts partitions, remove inputs only after
+their consumers migrate, deduplicate with explicit follows, and require each
+lock change to correspond to a proven output/capability boundary.
 
 The frozen predecessor may be deliberately thawed to repair code it still
 owns, then verified, re-pinned, and frozen again. Do not duplicate a capability

--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -46,8 +46,10 @@ requirements and accepted tradeoffs; the agent controls investigation,
 technical execution, and proof. For genuine requirement ambiguity, load
 `collaboration` and ask evidence-backed questions with alternatives,
 consequences, and a recommendation. Load `invariants` before defining public
-capability boundaries. Load `rootfs` whenever owner feedback teaches a durable
-new reasoning or collaboration rule.
+capability boundaries. Load `proof-budget` before rechecking a downstream fact
+already guaranteed by platform, overlay, input, or interface composition. Load
+`rootfs` whenever owner feedback teaches a durable new reasoning or
+collaboration rule.
 
 Current north star: fully and severably land the low-level Home Manager layer,
 push genuinely user-space `nixbook-pro` behavior into it, and prove it with two

--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -41,6 +41,9 @@ also updates them. After cloning or pulling on another computer, run
 `.agents/dendritic/context.sh sync-cache` and `verify-cache`. Never leave a
 cache-only architectural mutation: reconcile it into the canonical bundle,
 refresh, verify, commit, and push it for the next machine/model to consume.
+During long sessions, periodically make this canonical checkpoint so an
+out-of-file-descriptors cache flush or process restart resumes from recent
+committed context rather than conversation memory.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,

--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -49,9 +49,10 @@ is independent of the current Dendritic storage so the mechanics can evolve.
 Bounded checkpoint, propagation, cache verification, and isolated validation
 may be delegated asynchronously when shared-file ownership is non-overlapping.
 For bootstrap tooling, close over immutable logic/tools through Nix, late-bind
-the writable workspace via argument/environment/local discovery, validate it
+the writable workspace via explicit argument or local discovery, validate it
 before mutation, and preserve a baseline-shell recovery path without devshell
-or PATH assumptions.
+or PATH assumptions. Inherit environment roots only when the tool's state
+contract explicitly requires them.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,

--- a/.agents/dendritic/AGENTS.template.md
+++ b/.agents/dendritic/AGENTS.template.md
@@ -66,3 +66,8 @@ real consumers—nix-darwin-integrated HM and standalone HM—before hardening t
 less-mature high-level interfaces. A coexistence bridge on current `main` is a
 mandatory early deliverable: use it to move the epic to trunk-based incremental
 ports rather than growing another unmergeable Dendritic branch.
+
+The frozen predecessor may be deliberately thawed to repair code it still
+owns, then verified, re-pinned, and frozen again. Do not duplicate a capability
+into the bridge merely to carry a repair. This main-based migration line owns
+the sole policy bundle; predecessor-local copies are stale and must be removed.

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -19,7 +19,7 @@ operationally frozen Dendritic flake and exposes its module registries beneath
 `self.dendritic`, so
 later slices can port capability cones without rebasing the reconstructed
 branch or deleting unrelated legacy closures. The `dendritic` source is frozen
-at `0846de2f` and tagged `dendritic-suspended-2026-08-12`; treat it as a
+at `b1e091f8` and tagged `dendritic-suspended-2026-08-12`; treat it as a
 predecessor/source archive while migration proceeds from current `main`. The
 lock file pins the exact commit; the input URL names the protected branch rather
 than the immutable tag, so branch protection is part of the freeze guarantee.
@@ -30,6 +30,14 @@ predecessor still owns. When migration uncovers such a defect, temporarily thaw
 freeze coordinate/tag and bridge pin, then freeze it again. Do not internalize
 or duplicate a capability merely to carry its repair; source-ownership transfer
 is a separate landing justified by a coherent consumer cone.
+
+Publish protected/frozen-branch repairs through pull requests. Prepare and
+validate the complete final branch state, open a draft PR, promote/present it as
+final when checks and review evidence are complete, then stop for the owner's
+approval and merge. Do not bypass this by directly updating a protected branch.
+Because a tag move is not itself representable in the PR diff, move the freeze
+tag only after the owner merges the final PR that establishes its target commit;
+then update downstream lock pins in a separate reviewable landing.
 
 The active main-based migration branch owns the sole context-policy bundle.
 The predecessor must not retain a divergent `.agents/dendritic` bundle or root
@@ -331,14 +339,14 @@ port supersedes it. Do not replace it with `nix flake check`, `nix build
 
 Current durable coordinates as of 2026-08-12:
 
-- frozen predecessor branch: `dendritic` at `0846de2f`;
+- frozen predecessor branch: `dendritic` at `b1e091f8`;
 - frozen tag: `dendritic-suspended-2026-08-12`;
 - bridge landed on `main`: `c116a095` (source bridge commit `b341ba3c`);
 - current main-based HM migration branch: `dendritic-hm-foundation` (the name is
   historical; the public module/interface name is `base`, never `foundation`);
 - initial cross-platform HM base commit: `7ba2dae3`;
-- the Home Manager input-registry cone remains predecessor-owned while its
-  canonical-path defect is repaired and the source is re-frozen;
+- the Home Manager input-registry cone remains predecessor-owned; its public
+  path was repaired through PR #435 and re-frozen at `b1e091f8`;
 - the Dendritic branch was reconstructed through roughly one hundred small
   sequential commits, beginning with `Clean everything out` and rebuilding the
   flake and modules from a blank baseline.
@@ -670,7 +678,7 @@ evidence rather than filename inference.
 | Cachix binary-cache policy | accepted omission for thin slice | Main user Nix settings include krad246 Cachix; Dendritic user Nix settings do not. Old broad daemon/cache policy need not block first HM landing. |
 | broad per-user Nix policy | accepted omission for thin slice | Main evaluates many performance, sandbox, retention, timeout, and cache settings; Dendritic HM evaluates only `experimental-features = [nix-command flakes]` through the registry. |
 | input flake registry | architecturally superseded/win; predecessor-owned | Both expose registries. Dendritic replaces old `flake-registry` with the generic configurable input-registry source and locked/unlocked behavior. Preserve that design and repair it at its authoritative source until an intentional ownership-transfer landing. |
-| registry filesystem projection | changed, capability available | Main installs `~/nix/path/*` links unconditionally via `home-link-registry`. Dendritic has `input-registry.sysroot.install` and optional search-path projection, currently disabled for this consumer. Its public absolute path exposed a noncanonical `/./` artifact; fix this in Dendritic and re-freeze rather than duplicating the cone into the bridge. Selection policy remains to decide. |
+| registry filesystem projection | changed, capability available; path repaired | Main installs `~/nix/path/*` links unconditionally via `home-link-registry`. Dendritic has `input-registry.sysroot.install` and optional search-path projection, currently disabled for this consumer. PR #435 repaired its public absolute path from `/Users/krad246/./nix/path` to `/Users/krad246/nix/path` at the authoritative predecessor source. Selection policy remains to decide. |
 | dotfiles link/sync | accepted removal | Do not port the mutable synchronization/link behavior. |
 | XDG | changed | Main evaluates `xdg.enable=true`; Dendritic evaluates false, while both prefer XDG directories. Likely foundation parity item. |
 | manuals | changed | Effective Main: HTML false (Zen override), JSON true. Dendritic: HTML false, JSON false. Decide general HM manual policy independently of browser integration. |

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -1169,6 +1169,22 @@ as single-writer state: delegate either the complete checkpoint operation or
 read-only verification, and do not concurrently edit its inputs or generated
 outputs from another agent.
 
+Parallel implementation agents must own distinct worktrees and branches. Fetch
+and verify the expected remote tip before publishing, then push with both
+`--force-with-lease` and `--atomic`; never let parallel agents publish to the
+same branch.
+
+Treat legacy Generic Linux behavior as decision evidence, not an architecture
+to reproduce verbatim. Before migration or deletion, inventory the delta from
+the new Home Manager base and classify each item as portable intent,
+platform-specific implementation, or incidental legacy choice. Port only after
+an explicit owner retain/redesign/drop decision. In particular, Kitty is a
+potential backend of a terminal interface that can also admit Ghostty,
+Alacritty, and other implementations; it is not itself the portable interface.
+VS Code, VS Code server, and their related integrations are deferred outside the
+current migration scope. Preserve their legacy source locations in the decision
+inventory, but do not port them or treat them as parity or deletion gates.
+
 ### Mandatory architectural decision synchronization
 
 Conversation is not the durable source of truth. Whenever the owner makes a

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -361,6 +361,21 @@ maxJobs, TERM, bottom, coredumps, and protocol.
   preserved: its source/registry, filesystem sysroot projection, optional
   legacy search-path projection, and cross-context generic interface are a
   substantial improvement over the old registry plus home-link modules.
+- Zsh is intentionally removed and is not required in the first HM landing.
+- Preserve `condor-janitor0e@icloud.com` for Git through a local layered
+  override of the owner/general identity default.
+- Do not port HM Agenix in the thin HM slice. RBW remains selected.
+- Remove the old mutable dotfiles synchronization/link behavior.
+- Spotify Player is removed for now.
+- Do not port the current terminal-font architecture. It is incoherent and
+  inflates closures. Revisit fonts through a future theming capability lane and
+  its relationship to Stylix.
+
+The longer-term identity direction is a multi-identity software bus. Identity
+providers publish identities through a stable virtual interface; Git queries
+or selects from that bus and projects the selected identity through its own
+wrapping interface. The immediate local Git email override is a deliberate
+narrow bridge toward that design, not the final multi-identity API.
 
 ## Explicitly unfinished or exploratory areas
 
@@ -500,14 +515,14 @@ evidence rather than filename inference.
 |---|---|---|
 | username/home directory | preserved | Both evaluate to `krad246` and `/Users/krad246`. |
 | identity name | preserved | Both Git configurations use `Keerthi Radhakrishnan`; Dendritic derives it from `identity.person`. |
-| special Git email | missing/decision required | Main evaluates `condor-janitor0e@icloud.com`; Dendritic evaluates `krad246@gmail.com` from flake owner metadata. Decide whether Git needs a separate identity/account slot rather than changing the person default. |
+| special Git email | required local override | Preserve `condor-janitor0e@icloud.com` with a local layered Git override. Longer term select it from the multi-identity software bus rather than changing the general person default. |
 | RBW | preserved with better interface | Enabled in both. Dendritic derives email from `identity.person` and selects platform pinentry behind `identity.secrets.backends.rbw`. |
-| HM Agenix module/package | missing | Main has Agenix in the HM package closure; Dendritic does not import HM Agenix for this user. Decide whether Agenix and RBW are separate secret capabilities rather than alternatives. |
+| HM Agenix module/package | accepted removal | Do not port it in the thin HM slice. RBW remains selected. |
 | Cachix binary-cache policy | accepted omission for thin slice | Main user Nix settings include krad246 Cachix; Dendritic user Nix settings do not. Old broad daemon/cache policy need not block first HM landing. |
 | broad per-user Nix policy | accepted omission for thin slice | Main evaluates many performance, sandbox, retention, timeout, and cache settings; Dendritic HM evaluates only `experimental-features = [nix-command flakes]` through the registry. |
 | input flake registry | architecturally superseded/win | Both expose registries. Dendritic replaces old `flake-registry` with the generic configurable input-registry source and locked/unlocked behavior. Preserve Dendritic design. |
 | registry filesystem projection | changed, capability available | Main installs `~/nix/path/*` links unconditionally via `home-link-registry`. Dendritic has a general `input-registry.sysroot.install` projection and optional search-path projection, currently disabled for this consumer. Selection policy remains to decide; architecture is settled. |
-| dotfiles link/sync | missing/decision required | Main has `syncDotfiles`, `switchToSpecialisation`, and dotfiles file entries. Dendritic has none. Reassess whether mutable repo synchronization belongs in managed HM at all. |
+| dotfiles link/sync | accepted removal | Do not port the mutable synchronization/link behavior. |
 | XDG | changed | Main evaluates `xdg.enable=true`; Dendritic evaluates false, while both prefer XDG directories. Likely foundation parity item. |
 | manuals | changed | Effective Main: HTML false (Zen override), JSON true. Dendritic: HTML false, JSON false. Decide general HM manual policy independently of browser integration. |
 | state version | version drift | Main evaluates 26.05 and Dendritic 25.11 due branch input eras. Resolve intentionally during port; do not copy one blindly. |
@@ -519,7 +534,7 @@ evidence rather than filename inference.
 | Bash `tldr` alias | changed | Main defines executable-resolved alias; Dendritic installs `tldr` but does not define that alias. Likely harmless, verify desired UX. |
 | Bash-Yazi wrapper | preserved | Both provide `y()` with cwd-file behavior; Dendritic gates it through explicit integration. |
 | Bash integrations | architecturally improved, parity incomplete | Dendritic explicitly dispatches Direnv, FZF, LSD, Kitty, Starship, Yazi, and Zoxide. Old Kitty+FZF image-preview environment behavior is not visibly reproduced. |
-| Zsh | missing/decision required | Main enables and configures Zsh; Dendritic selected profile disables Nushell and does not enable Zsh. Determine whether Zsh remains a backend requirement or accepted removal. |
+| Zsh | accepted removal | Do not port or select Zsh for the first HM landing. |
 | Bat theme | preserved | Gruvbox dark in both; Dendritic also sets terminal title. |
 | Bat extras | changed | Main includes batdiff, batgrep, batman, batpipe, batwatch, prettybat. Dendritic effective closure includes batdiff, batgrep, batman, prettybat but not batpipe/batwatch as packages. Batpipe is invoked conditionally through a Bash integration and needs closure validation. |
 | Bat aliases/environment | changed | Main aliases `cat` to `bat -pp`, resolves `brg`/`man`/`bdiff` to store executables, and sets BATDIFF/LESSOPEN/LESS/BATPIPE. Dendritic aliases `bat` to `prettybat`, keeps `brg`/`man`/`bdiff` by command name, sets BATDIFF, and delegates LESS/PAGER to its pager capability. It drops the old `cat` alias and batpipe `LESSOPEN`/`BATPIPE` environment. Decide desired composition rather than blindly restore. |
@@ -535,11 +550,11 @@ evidence rather than filename inference.
 | Helix languages | regression plus deliberate additions | Dendritic adds Nix/nixd but drops Rust, docker-compose, Bash shfmt, rust-analyzer, and systemd server declaration. More seriously, evaluated output nests language entries under `languages.language` instead of top-level `language`, suggesting an erroneous extra `languages` level in the module. Fix before HM landing. |
 | FZF-Helix edit action | structurally preserved | Both build a no-suspend Helix wrapper; Dendritic exposes it through picker action vTable. Test produced command. |
 | LSD | preserved exactly | Normalized effective configuration hashes match. |
-| terminal fonts | missing/partial | Main HM closure includes Cascadia Code, Meslo, and symbols fonts; Dendritic gets Meslo through Kitty styling only. General terminal-font capability is absent. |
+| terminal fonts | accepted architectural removal/deferral | Do not port the old font bundle. It is incoherent and bloats closures. Kitty's direct font realization may remain only as backend-local behavior pending a future theme/Stylix capability design. |
 | Kitty terminal | preserved plus explicit integration | Enabled in both. Normalized effective settings, keybindings, theme, font, launch options, and shell-integration values match modulo store path. Dendritic additionally enables HM's Git integration through an explicit Git-Kitty capability relationship; Main leaves it false. |
 | base package set | changed | Main-only notable tools include `safe-rm`, `procs`, `has`; Dendritic adds a larger dev/interactive set including curl, file, jq, tree, archives, CMake/GDB/binutils, and Nix diagnostics. Classify by preset lane rather than demand exact set equality. |
 | Ripgrep + ripgrep-all | preserved | Both enabled. Dendritic integration split provides Bat behavior. |
-| Spotify Player | missing/decision required | Enabled on Main, disabled on Dendritic. Decide whether it belongs in the HM slice/profile. |
+| Spotify Player | accepted removal | Drop it for now. |
 | Starship | preserved exactly | Normalized settings hashes match; Dendritic shell integration is explicit. |
 | Yazi keymap | preserved exactly | Normalized keymap hashes match. |
 | Yazi settings | preserved modulo HM defaults | Normalized diff shows Dendritic adds only empty `opener`, `plugin`, and `which` sets; authored manager/input/preview behavior is otherwise equal. Keymap is exactly equal. |

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -1093,6 +1093,23 @@ public command generic: today it delegates to the Dendritic bundle's
 replace or extend that storage without renaming the lifecycle action. A matching
 Just command namespace is a possible convenience layer, not current scope.
 
+Bootstrap and recovery tooling follows one boundary: statically close over
+tools and immutable logic; late-bind mutable workspace locations and recovery
+inputs. Nix applications should capture executables, libraries, and exact script
+implementations through typed derivations/store paths, but must not capture an
+immutable source-store copy as the writable checkout. Resolve mutable roots in
+this order: explicit command argument, explicit environment override such as
+`FLAKE_ROOT`, then an invocation-local fallback such as `$PWD`/ancestor
+discovery. Validate the selected root, expected markers, bundle contents, and
+root/bundle coherence before mutation.
+
+Keep the underlying recovery primitive directly runnable with a baseline shell
+and explicit arguments when `direnv`, the development shell, or repository PATH
+setup is broken. Nix apps and Just recipes are typed/convenient front doors over
+that primitive, not its only execution path. Ambient environment is an override
+and recovery seam for mutable inputs, not a substitute for statically declaring
+ordinary tool dependencies.
+
 Checkpoint/propagation work may run in a bounded sub-agent while the primary
 agent continues an independent implementation lane. Treat the canonical bundle
 as single-writer state: delegate either the complete checkpoint operation or

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -424,18 +424,18 @@ Status meanings:
 | console access disabled | missing | Old set `DisableConsoleAccess=true`; no current realization found. |
 | screensaver password | missing | Old set `screensaver.askForPassword=true`; current screensaver module is empty. |
 | custom preference dispatch | unverified | Old copied `CustomUserPreferences` to `CustomSystemPreferences`; new HM Darwin target writes domains through `targets.darwin.defaults`. Compare generated activation/defaults behavior. |
-| dark mode | static match | New desktop defaults request dark, nonautomatic style. Evaluate. |
-| Finder settings | static match | Hidden/extensions, desktop, search scope, view, trash cleanup, path/status bars, POSIX title, folders-first are mapped. |
-| menu/dialog preferences | static match | Expanded save/print panels, table mode, visible menu bar mapped. |
-| pointer/trackpad | static match | Flat mouse acceleration, non-natural scrolling, right-click, corner/scaling values represented. |
-| keyboard basics | static match through HM dispatcher | Full keyboard access, repeat rates, text substitutions, function-key mode, window animations, and Fn usage intent are represented in the Dendritic desktop vTable/Darwin dispatcher. Evaluate generated HM Darwin defaults rather than only nix-darwin `system.defaults`, because responsibility moved layers. |
+| dark mode | preserved through HM dispatcher | Evaluated HM Darwin defaults request dark, nonautomatic style. |
+| Finder settings | preserved through HM dispatcher | Evaluated defaults preserve hidden/extensions, desktop, search scope, view, trash cleanup, path/status bars, POSIX title, and folders-first. |
+| menu/dialog preferences | preserved through HM dispatcher | Evaluated defaults preserve expanded save/print panels, table mode, and visible menu bar. |
+| pointer/trackpad | preserved through HM dispatcher | Evaluated defaults preserve flat acceleration, non-natural scrolling, right-click, corner, and scaling values. |
+| keyboard basics | preserved through HM dispatcher | Evaluated HM defaults contain full keyboard access, repeat rates, text substitutions, function-key mode, window animations, and HIToolbox Fn usage. Responsibility moved from nix-darwin defaults to HM activation. |
 | symbolic keyboard shortcuts | missing | Main's evaluated nix-darwin configuration contains 87 `com.apple.symbolichotkeys.AppleSymbolicHotKeys` entries. Dendritic's `desktop.input.keyboard.shortcuts` interface is empty and no equivalent mapping exists. This is a substantial unported desktop lane, not covered by the basic keyboard options. |
-| Spotlight order | static match | Same explicit ordered list exists in Darwin HM dispatcher. |
-| window manager/spaces | mostly static match | Old values represented; evaluate exact domains/types. |
-| Dock constants | mostly static match | Old autohide, magnification, tile size, corners, recents, etc. represented. |
-| Dock apps | partial | Old pinned iPhone Mirroring + Launchpad, and host prepended Zen. New defaults request logical browser, phone-mirroring, launchpad, file-manager, terminal, editor. Darwin dispatcher only maps browser/phone/launchpad, filtering unknown IDs, so effective list is Zen + phone + launchpad. Confirm ordering and whether omitted logical roles need real backends. |
+| Spotlight order | preserved through HM dispatcher | Evaluated HM defaults contain the same explicit ordered list. |
+| window manager/spaces | preserved through HM dispatcher | Evaluated domains preserve the legacy WindowManager values and `spans-displays=false`. |
+| Dock constants | preserved through HM dispatcher | Evaluated HM defaults preserve old autohide, magnification, tile size, corners, recents, and related values. |
+| Dock apps | behavior preserved, interface partial | Effective Dendritic list is Zen, iPhone Mirroring, Launchpad, matching Main's host-prepended Zen plus two base pins and intended order. Defaults also request file-manager, terminal, and editor IDs, but the dispatcher silently filters them because no path providers exist. Current behavior matches while the logical dock contract remains incomplete. |
 | Tailscale | static match | Darwin service enabled. |
-| Linux builder | superseded/unverified | Better architecture. Both enable ephemeral builder with maxJobs 60; Main advertises i686/x86_64/aarch64 Linux while Dendritic advertises only x86_64/aarch64. Complete guest config and decide whether i686 removal is accepted. |
+| Linux builder | architecturally superseded; two regressions | Final embedded guest evaluation proves both preserve aarch64 host platform, 8 cores, 16 GiB RAM, 64 GiB disk, ccache, swapspace, zram, 16 GiB `/swapfile`, `TERM=xterm-256color`, Bottom, and disabled coredumps. Dendritic drops i686 from advertised/emulated systems. It also imports `environment.enableAllTerminfo`, pulling many terminal-emulator packages into the guest runtime closure; remove or replace this broad realization. Nix policy differs with branch era and should be classified separately. |
 | Dullahan/Gremlin/Fortress remotes | missing | Must be redesigned as capability/backends, not copied as host bundle. |
 
 Evaluated system package placement also confirms expected accepted removals:
@@ -445,6 +445,14 @@ Discord as a system Nix package. `m-cli` moves from Main's system package set to
 the Dendritic owner HM package set. Both retain Tailscale and the normal
 nix-darwin packages. The login shell changes from `/opt/homebrew/bin/bash` to
 Nixpkgs Bash as explicitly accepted.
+
+The three legacy remote modules are imported into the old logical source and
+option closure but all are disabled for `nixbook-pro`, so they contribute no
+effective builder/SSH configuration or derivation closure today. Their intent
+contains at least three separable concerns: named SSH endpoints, proxy-jump
+routes to nested builders (`headless-penguin`/`smeagol`), and Nix distributed
+build-machine scheduling. Future design should not assume one module per named
+host is the correct capability boundary.
 
 ### Applications and accepted removals
 

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -1,0 +1,666 @@
+# Dendritic migration: canonical operational context
+
+Read this entire file before changing architecture, rebasing, deleting legacy
+modules, or proposing a migration plan. This is both a project charter and an
+operational handoff for future Codex/model versions. Do not reduce it to a
+generic "modernize the Nix flake" task.
+
+## Mission and stopping condition
+
+The long-lived `dendritic` feature branch cannot land as one repository-wide
+rewrite. Incrementally land its architecture on `main`, beginning with the full
+logical closure of `nixbook-pro`, and leave a bridge on `main` through which
+later sessions can port coherent slices from `dendritic` without repeating its
+structural-rebase problem. Continue the epic until the remaining machine
+closures have been migrated.
+
+The immediate sequence is:
+
+1. finish a behavioral and architectural diff of the complete old and new
+   `nixbook-pro` closures;
+2. polish the low-level Home Manager experience until it is independently
+   landable and production quality;
+3. derive an explicit dependency graph and concrete commit plan;
+4. create a bridge commit on `main` that permits legacy and Dendritic structures
+   to coexist;
+5. port capability lanes and machine closures in coherent, verified commits.
+
+The coexistence bridge is mandatory and urgent, not an optional cleanup after
+the HM design is perfected. The migration cannot land without converting this
+long-lived feature-branch effort into trunk-based incremental work. Do enough
+closure analysis to design the bridge correctly, then land the bridge on
+current `main` and route the polished HM slice through it. Do not continue
+accumulating a second unmergeable architecture on `dendritic`.
+
+The current highest-value landing hypothesis is a complete, correct, general,
+and severable Home Manager substrate with two immediate consumers:
+
+1. Home Manager integrated into `nixbook-pro` through nix-darwin;
+2. a standalone Home Manager configuration.
+
+Push as much of `nixbook-pro` as is genuinely user-space into this common HM
+layer. The point is not to force system responsibilities into HM; it is to
+isolate and prove the user-experience closure once, against two real
+composition modes, before finishing the less-mature Darwin and host lanes.
+
+Do not call the migration complete because `nixbook-pro` evaluates, because a
+subset of tests pass, or because the branch is mergeable. Completion means the
+architecture and subsequent machine ports described here are actually landed
+and verified.
+
+## Authoritative architectural intent
+
+Systems are to be reconstructed from imports of capability interfaces, not
+from host-shaped or platform-shaped implementation bundles.
+
+Each capability owns a virtual module namespace. By convention the virtual
+namespace has the same name as the module/capability. Treat the namespace as a
+vTable:
+
+- consumers program against the virtual interface;
+- concrete backends are derived implementations beneath that interface;
+- presets select implementations and defaults but are not interfaces;
+- integrations implement relationships between two capabilities and should be
+  separately severable where either endpoint can exist without the other.
+
+For example, a picker consumer should request candidate production, preview,
+view, or edit operations. It should not construct FZF commands. FZF is one
+backend for the picker vTable; FD, Bat, and Helix integrations populate parts of
+the contract. Likewise, a consumer of a browser should depend on the logical
+browser/open operation, not directly on Zen or its installation mechanism.
+
+The required properties are:
+
+- interface declarations are severable from backend implementations;
+- a backend can be replaced without editing its consumers;
+- integrations are explicit and independently severable;
+- disabling a backend removes its packages from the realized derivation
+  closure;
+- source, evaluation, and derivation closure are distinct concepts;
+- evaluation scope should also remain lightweight, even where Nix laziness
+  keeps a package out of the realized derivation closure;
+- module composition remains transitively lightweight: importing a composition
+  must not silently acquire unrelated capabilities;
+- a virtual namespace corresponds to one stable atomic capability, not merely
+  to a small file;
+- host modules contain machine facts, explicit policy selections, and genuine
+  exceptions rather than reusable implementations;
+- platform modules dispatch or realize capability intent; they should not be
+  the only place the intent can be expressed.
+
+### Closure-discipline priority and accepted dispatch cost
+
+Do not flatten every kind of minimality into one metric. The intended priority
+is roughly:
+
+1. **flake-input graph discipline**: ruthlessly deduplicate inputs, use explicit
+   `follows`, use auto-follow machinery where appropriate, and prune unused lock
+   nodes;
+2. **derivation/runtime closure minimality**: disabled or unrelated
+   implementations must not be installed or retained by the built result;
+3. **module-level severability**: consumers, interfaces, implementations, and
+   integrations must be independently composable at the correct capability
+   boundary;
+4. **evaluation minimality**: desirable, measured, and improved, but the lowest
+   priority of these closure disciplines.
+
+Some evaluation enlargement is the ordinary cost of vTable-like dispatch: the
+evaluator may need the interface, variants, and visitor/dispatch trampoline
+resident in memory so it can choose a backend. Do not contort a clean virtual
+interface merely to eliminate this expected cost. Flag evaluation behavior
+when it forces expensive inputs or implementation values unnecessarily, but
+distinguish that from the acceptable residency needed to make variants
+available for dispatch.
+
+Input minimality is not optional just because evaluation minimality ranks
+lower. The current Dendritic substrate deliberately uses `nix-auto-follow`,
+explicit `inputs.*.follows`, empty follows where an upstream input is genuinely
+unneeded, and `flake-file` lock pruning. Preserve this discipline and verify the
+generated lock graph rather than accepting duplicate Nixpkgs/Home Manager trees
+as incidental flake churn.
+
+There is also a not-yet-realized ambition for flake-parts module-level
+severability/applicability—ideas such as `importApplies` and related machinery.
+Do not claim this exists today. Record cases where flake modules are resident or
+applied too broadly so that a future substrate can make applicability explicit,
+but do not block the HM landing on inventing the entire mechanism first.
+
+Atomicity is semantic. A 150-line backend may be one correct capability. Ten
+five-line files are still a monolith if they always activate together or can
+only be consumed as a bundle.
+
+### Profiles
+
+Profiles are intentionally opinionated presets. They compose through imports
+and enable/default declarations, ordinarily using `mkDefault` so callers can
+replace selections. Do not criticize a profile merely for choosing Bash,
+Helix, FZF, Kitty, or Zen. Do flag a profile if selecting one intended lane
+activates unrelated capabilities or prevents backend substitution.
+
+Keep these categories conceptually distinct:
+
+1. interface modules define vTables/contracts;
+2. backend modules realize a contract;
+3. integration modules connect contracts;
+4. profiles/presets import coherent capability sets and select defaults;
+5. hosts supply machine facts and exceptional policy.
+
+The highest-level interfaces and presets are expected to be the least mature.
+Do not prematurely freeze them merely to make the current tree look finished.
+
+### First polished landing: low-level Home Manager
+
+The shell work establishes the intended pattern even though its feature set is
+not finished. The first production-quality landing should be the low-level Home
+Manager substrate: shell, picker, programs, editor, terminal, identity/secrets,
+and their backends and integrations. High-level browser, application-store,
+dock, desktop, and final workstation taxonomy can remain exploratory while this
+substrate is stabilized.
+
+For the HM substrate, require at least:
+
+- interfaces that do not select implementations;
+- backend `enable` separate from `default` where multiple active backends or a
+  default role are meaningful;
+- integrations that do not unexpectedly enable both endpoints;
+- disabled backend packages absent from derivation closures;
+- backend-only package universes, including unstable Nixpkgs, not forced merely
+  by interface availability where practical;
+- minimal, interactive, development, and standalone compositions tested
+  separately;
+- the same capability modules usable by standalone HM and system-integrated HM;
+- no consumer knowledge of FZF/Helix/Kitty/etc. when a logical contract is
+  sufficient.
+
+## `ezConfigs` and flake composition
+
+`ezConfigs` is legacy infrastructure, not a migration target. It was useful on
+`main` because it discovered host/home modules and coupled user Home Manager
+modules into system configurations. Dendritic composition makes that machinery
+unnecessary and it is not a good architectural fit.
+
+Do not preserve, port, wrap, or recreate `ezConfigs` merely for compatibility.
+Its old behavior must be understood when calculating the old logical closure,
+but the new system should express that behavior directly through virtual
+modules and imports.
+
+Do not assume another existing flake-parts host/configuration interface is the
+desired replacement. None is currently known to fit this architecture well.
+`flake-parts` may still provide the flake module substrate, and `flake-file` plus
+`import-tree` currently provide generated-input and Dendritic module discovery,
+but host composition belongs to the project's own capability modules.
+
+## Branch topology and migration hazard
+
+At the time this handoff was written:
+
+- working branch: `dendritic` at `5940c9bf` before this handoff commit;
+- remote tracking branch: `origin/dendritic` at the same commit;
+- `main` at `315488c2` in the primary repository branch listing;
+- a separate worktree at `./main` is on `general-longstanding-cleanup` at
+  `6e2ecfb4` and must not be mistaken for the `main` branch;
+- merge base between `main` and `dendritic`: `f851783b`;
+- `dendritic` was reconstructed through roughly one hundred small sequential
+  commits, beginning with `Clean everything out` and rebuilding the flake and
+  modules from a blank baseline.
+
+Always re-check these facts. They are historical coordinates, not permanent
+truth. Use `git status --short --branch`, `git branch -vv`, `git worktree list`,
+and `git merge-base main dendritic` before acting.
+
+The branches also differ in dependency era. Current `main` has moved to 26.05
+inputs in its generated flake, while `dendritic` currently uses 25.11 for
+Nixpkgs, Home Manager, and nix-darwin. Never treat lockfiles or generated
+`flake.nix` as mechanically interchangeable. Do not solve this with a giant
+rebase. The bridge must make coexistence and incremental ports possible.
+
+The Dendritic branch's broad diff (previously measured as 475 files, about 6,374
+insertions and 12,402 deletions) is a consequence of reconstruction, not a
+reasonable landing unit. Avoid deleting unrelated legacy hosts or modules as a
+side effect of landing `nixbook-pro`.
+
+## Correct definition of the old `nixbook-pro` logical closure
+
+Do not inspect only `configurations/darwin/nixbook-pro`.
+
+On `main`, `flakeModules/ezConfigs/flake-module.nix` declares:
+
+```nix
+ezConfigs.darwin.hosts.nixbook-pro.userHomeModules = ["krad246"];
+```
+
+That injects `configurations/home/krad246.nix` into the host. The old logical
+closure therefore contains both:
+
+1. direct Darwin roots:
+   - `configurations/darwin/nixbook-pro/default.nix`;
+   - `configuration.nix`;
+   - `remotes.nix`;
+   - Darwin `apps`, `base-configuration`, `colima`, `macos-container`, and
+     `tailscale` imports;
+2. the user HM root:
+   - `configurations/home/krad246.nix`;
+   - `homeModules.base-home` and every transitive import;
+   - generic Cachix, Nix core, flake registry, and home-link registry modules.
+
+The old host also adds a host-local HM import enabling Codex from unstable.
+
+Trace actual option definitions and the merged module result. Similar filenames
+or namespaces are not evidence of behavioral parity.
+
+## Current Dendritic `nixbook-pro` root and composition
+
+`modules/hosts/nixbook-pro/configuration.nix` creates
+`flake.darwinConfigurations.nixbook-pro` and imports:
+
+```text
+darwin.workstation
+├── darwin.applications
+├── darwin.base
+│   ├── home-manager
+│   ├── input-registry
+│   ├── nix
+│   ├── nixpkgs-instance
+│   └── owner
+├── darwin.desktop
+│   ├── app-stores
+│   ├── browser
+│   └── homeManager.desktop for owner
+├── darwin.dev
+│   └── homeManager.dev for owner
+└── darwin.secrets
+    └── homeManager.secrets for owner
+
+darwin.linux-builder
+darwin.tailscale
+host-specific inline modules
+```
+
+The owner HM composition reaches:
+
+```text
+homeManager.base
+├── identity
+├── input-registry
+└── shell
+
+homeManager.desktop
+├── browser
+└── terminal
+
+homeManager.dev
+├── editor
+└── shell.profiles.dev
+
+homeManager.secrets
+└── RBW backend
+```
+
+The host-specific inline modules currently own the aarch64-darwin platform,
+hostname, UID/GID, Bash login shell, DNS/network naming, Nix daemon exceptions,
+deep-cache tuning, trusted owner, Touch ID, macOS updates, and Linux-builder VM
+sizing.
+
+## Strongest architectural results so far
+
+### Shell/picker/program composition
+
+This is the reference pattern. Important layers include:
+
+- `shell.profiles.interactive` and `shell.profiles.dev`: preset policy;
+- `shell.programs.*`: logical tool capabilities;
+- `shell.backends.bash` and `.nushell`: concrete shells;
+- `picker`: logical sources, actions, and bindings;
+- `picker.backends.fzf`: concrete picker;
+- narrowly scoped integrations such as FZF-FD, FZF-Bat, FZF-Helix,
+  Delta-Git, Delta-Lazygit, Git-GH, Git-Kitty, Bash-Yazi, etc.
+
+The picker interface's sources/actions are a better boundary than exposing FZF
+command fragments to consumers. Preserve and extend that pattern.
+
+There are still rough edges. Some program modules are aliases directly onto HM
+`programs.*.enable`, the shell base wires many defaults, and package/evaluation
+laziness has not been systematically proven. Treat shell as the pattern source,
+not as finished code immune from audit.
+
+### Remote Linux builder
+
+The old `base-configuration/linux-builder.nix` combined public options,
+nix-darwin realization, guest NixOS configuration, binfmt, ccache, packages,
+swap, TERM, coredumps, and VM sizing.
+
+The current structure separates:
+
+- `remoteBuilder`: generic interface;
+- `remoteBuilder.backends.linux-builder`: Darwin/nix-darwin backend;
+- `nixos.remote-builder`: reusable guest preset;
+- host-provided `remoteBuilder.configuration`: deferred guest overrides.
+
+This is architecturally strong and demonstrates composition across a nested
+system boundary. Functional parity remains unproven and must cover advertised
+systems, binfmt, ccache, swapspace/static swap, zram, VM cores/RAM/disk,
+maxJobs, TERM, bottom, coredumps, and protocol.
+
+## Explicit owner decisions: do not reopen without new direction
+
+- Arc is removed.
+- LaunchControl is removed.
+- Zen is retained.
+- Discord is added.
+- Colima is intentionally excluded from this port.
+- `macos-container` is intentionally excluded from this port.
+- Using Nixpkgs `bashInteractive` instead of the Homebrew Bash is acceptable for
+  the narrowed slice.
+- Homebrew itself is not forbidden. It may remain or return behind a sound
+  capability; it was initially narrowed out because of porting friction.
+- Profiles are presets and may compose through imports and enable/default
+  declarations.
+
+## Explicitly unfinished or exploratory areas
+
+Do not mistake existence for endorsement:
+
+- remote definitions for `dullahan`, `gremlin`, and `fortress` are missing
+  because their lane still needs rearchitecture; their disappearance is not an
+  accepted feature removal;
+- `appStore` has had effectively zero serious interface-design thought and is
+  exploratory;
+- browser and related high-level interfaces are exploratory;
+- dock may be half-baked;
+- the highest-level profiles/interfaces are generally the least baked;
+- evaluation-scope enlargement is known and should be recorded, prioritized,
+  and fixed after/alongside derivation-closure correctness;
+- every old `base-configuration` behavior must be checked explicitly.
+
+Do not expend early work defending or polishing app-store/browser/dock APIs as
+if they were settled. First use closure evidence to determine their correct
+capability boundaries.
+
+## Behavioral parity ledger (evidence as of this handoff)
+
+Status meanings:
+
+- **preserved**: evidence establishes equivalent effective behavior;
+- **static match**: source mappings look equivalent, but evaluated output still
+  needs proof;
+- **accepted change**: owner explicitly accepts the difference;
+- **missing**: legacy behavior is in the old closure and has no current
+  realization;
+- **unverified**: replacement exists but parity is not proven;
+- **irrelevant**: old module contributed no active behavior;
+- **superseded**: a deliberately different capability fulfills the intent, with
+  details still subject to parity audit.
+
+### Host and Darwin base
+
+| Legacy responsibility | Status | Current evidence / required follow-up |
+|---|---|---|
+| macOS automatic updates | preserved | Set directly in current host. |
+| hostname, localHostName, computerName | preserved | Set from `networking.hostName`. |
+| Cloudflare and Google IPv4/IPv6 DNS | preserved | Same values set by host. |
+| `NIX_REMOTE=daemon` | preserved | Set by host. |
+| `auto-allocate-uids=false` | preserved | Set by host. |
+| `auto-optimise-store=false` | preserved | Set by host. |
+| `/nix/store` extra sandbox path | preserved | Set by host. |
+| `keep-derivations=true` | preserved | Set by host. |
+| `max-substitution-jobs=60` | preserved | Set by host. |
+| owner UID/GID 501/20 | preserved | Host sets user IDs. |
+| primary owner, description, home | static match | `darwin.owner` supplies these; evaluate final user record. |
+| trusted owner | preserved | Host sets `nix.settings.trusted-users`. |
+| Touch ID for sudo | preserved | Set by host. |
+| nixbld GID 350 | preserved | Current `darwin.nix`. |
+| system Agenix module and custom Agenix package | missing | `darwin.secrets` only bridges HM RBW; it does not import `darwin.agenix` or install the prior tool. Decide desired system/HM secret capabilities. |
+| firewall | irrelevant | Old file contained comments only. |
+| system terminal fonts | missing | Old `fonts.packages = pkgs.krad246.term-fonts.paths`; no equivalent found in current host cone. |
+| HM bridge package universe | changed/unverified | Old had `useGlobalPkgs=true`, `useUserPackages=true`, `verbose=false`; new leaves global pkgs off, uses user packages, and is verbose. Audit package identity/overlays/unfree effects before choosing policy. |
+| Homebrew substrate | changed/unverified | Old imported nix-homebrew but defaulted it and Homebrew off, still added `mas` and prefix/shell declarations. Current app-store selection activates Homebrew. Compare effective behavior, not declarations. |
+| guest login disabled | missing | Old master-user module set `GuestEnabled=false`; current lock-screen modules are empty. |
+| console access disabled | missing | Old set `DisableConsoleAccess=true`; no current realization found. |
+| screensaver password | missing | Old set `screensaver.askForPassword=true`; current screensaver module is empty. |
+| custom preference dispatch | unverified | Old copied `CustomUserPreferences` to `CustomSystemPreferences`; new HM Darwin target writes domains through `targets.darwin.defaults`. Compare generated activation/defaults behavior. |
+| dark mode | static match | New desktop defaults request dark, nonautomatic style. Evaluate. |
+| Finder settings | static match | Hidden/extensions, desktop, search scope, view, trash cleanup, path/status bars, POSIX title, folders-first are mapped. |
+| menu/dialog preferences | static match | Expanded save/print panels, table mode, visible menu bar mapped. |
+| pointer/trackpad | static match | Flat mouse acceleration, non-natural scrolling, right-click, corner/scaling values represented. |
+| Spotlight order | static match | Same explicit ordered list exists in Darwin HM dispatcher. |
+| window manager/spaces | mostly static match | Old values represented; evaluate exact domains/types. |
+| Dock constants | mostly static match | Old autohide, magnification, tile size, corners, recents, etc. represented. |
+| Dock apps | partial | Old pinned iPhone Mirroring + Launchpad, and host prepended Zen. New defaults request logical browser, phone-mirroring, launchpad, file-manager, terminal, editor. Darwin dispatcher only maps browser/phone/launchpad, filtering unknown IDs, so effective list is Zen + phone + launchpad. Confirm ordering and whether omitted logical roles need real backends. |
+| Tailscale | static match | Darwin service enabled. |
+| Linux builder | superseded/unverified | Better architecture; perform detailed parity evaluation. |
+| Dullahan/Gremlin/Fortress remotes | missing | Must be redesigned as capability/backends, not copied as host bundle. |
+
+### Applications and accepted removals
+
+Old apps included Arc, Bluesnooze, GroupMe, LaunchControl, Magnet, Signal, UTM,
+Zen, and Zoom. Current application declarations add Discord and preserve most of
+that set through symbolic variants, but centralized tool policy selects no Arc
+and no LaunchControl. Those two removals and Discord addition are accepted.
+
+The current application-store design has known flaws, not migration invariants:
+
+- `appStore.tools.<tool>.enable` conflates availability with activation;
+- the `applications` preset enables all tools rather than deriving activation
+  from selected/resolved demand;
+- Homebrew/`mas`/unfree policy can therefore enter a closure too broadly;
+- selection is a closed central mapping, so a newly declared logical
+  application is ignored until that mapping changes;
+- variant and resolved values are weakly typed (`anything`-like contracts);
+- installation policy, backend availability, backend activation, and logical
+  application declaration are insufficiently separated.
+
+Do not preserve these flaws for compatibility. Redesign after understanding
+actual machine/application lanes.
+
+### Home Manager legacy closure: required audit
+
+This audit is not finished. The old `krad246` HM root sets username/home from
+the OS user, overrides Git email to `condor-janitor0e@icloud.com`, and imports:
+
+- complete `base-home`;
+- `krad246-cachix`;
+- generic Nix core;
+- flake registry;
+- home-link registry.
+
+`base-home` imports Agenix, Bash, Bat, Bitwarden/RBW, Bottom, Direnv, FD, FZF,
+Git, Helix, LSD, terminal fonts, packages, Ripgrep, Spotify Player, Starship,
+Yazi, Zoxide, and Zsh. It also owns activation, XDG, manuals, state version, and
+dotfiles behavior.
+
+The next agent must make a row-by-row old/new ledger for at least:
+
+- identity name/username/email and the special Git email override;
+- Agenix HM module and package versus RBW capability;
+- Cachix configuration;
+- Nix settings and package universe;
+- flake registry and home/system link registries;
+- Bash behavior: vi mode, completion, VTE, Ctrl-H, reload alias, history rules,
+  `tldr`, Yazi wrapper, Kitty/FZF image preview integration;
+- Zsh behavior and whether its removal/nonselection is intentional;
+- Bat theme, extras, aliases, BATDIFF/LESSOPEN/BATPIPE behavior;
+- Bottom Linux desktop hiding;
+- Direnv/nix-direnv and per-shell integrations;
+- FD hidden/default options;
+- old FZF widgets, bindings, preview/view/edit commands, and source semantics;
+- Git identity, LFS, aliases, delta, GH credentials, Kitty integrations;
+- Helix package (`evil-helix` currently), languages, settings, keymaps, and FZF
+  editor integration;
+- LSD colors, hyperlinking, aliases, and shell integration;
+- terminal font packages and Linux fontconfig;
+- package lists, including lost/added tools (`safe-rm`, `procs`, `has`, etc.);
+- Ripgrep and ripgrep-all;
+- Spotify Player (apparently absent in current cone);
+- Starship settings and shell integration;
+- Yazi settings/keymaps/integrations;
+- Zoxide integrations;
+- Codex moved from host-local import to development preset;
+- old dotfiles sync activation and out-of-store link behavior;
+- manual HTML/JSON behavior, including old Zen manual opener behavior;
+- XDG configuration and Home Manager state version.
+
+For each item classify preserved, accepted change, missing, irrelevant, or
+unverified and cite exact option/config evidence. Do not infer parity from a new
+file having the same tool name.
+
+## Known closure/evaluation concerns
+
+Use three separate measurements:
+
+1. **source closure**: files/modules discovered or imported;
+2. **evaluation closure**: inputs, package sets, and module values forced while
+   evaluating;
+3. **derivation/runtime closure**: store paths reachable from built results.
+
+Primary acceptance requires disabled implementations to stay out of derivation
+closures. Evaluation lightness remains part of the vision and must be improved
+in prioritized passes, but it is deliberately lower priority than input-graph
+discipline, derivation closure, and sound interface severability. A resident set
+of backend variants plus dispatch machinery can be an acceptable vTable tax.
+
+Examples already observed:
+
+- Kitty imports `nixpkgs-unstable` and assigns `pkgs.unstable.kitty` even when
+  its backend is disabled. Laziness may keep Kitty out of the derivation, but
+  mere backend availability can enlarge evaluation scope.
+- Bottom, Lazygit, and Codex similarly select unstable packages in modules that
+  may be imported before enablement.
+- Interface declarations should remain available without forcing backend-only
+  package sets where possible.
+- Importing an integration must not silently install both endpoints unless the
+  profile explicitly requests both.
+
+Create real checks/fixtures rather than relying on source inspection. A useful
+matrix includes bare HM interface, minimal shell, interactive shell, dev shell,
+each backend disabled/enabled, standalone HM, system-integrated HM, and backend
+replacement. Inspect derivation references or closure paths for forbidden
+packages.
+
+## Acceptance gates for the `nixbook-pro` slice
+
+All of these remain required unless the owner explicitly revises them:
+
+- `nixbook-pro` evaluates and builds independently;
+- its nested Linux-builder guest evaluates independently;
+- disabled backends do not enter derivation closures;
+- replacing Bash, Helix, FZF, Kitty, Zen, or an application installation tool
+  does not require editing consumers;
+- profile composition does not activate unrelated capabilities;
+- every imported capability is used or required to expose a stable consumed
+  interface;
+- all functional deviations from `main` are explicit and accepted;
+- Colima and `macos-container` remain intentionally excluded;
+- application tools eventually activate from resolved demand, not mere
+  availability;
+- remote-machine definitions are rearchitected rather than silently lost;
+- the slice can merge without deleting unrelated legacy hosts/closures;
+- the low-level HM layer has standalone and integrated composition evidence;
+- input-version differences are resolved intentionally, not hidden by lockfile
+  churn.
+
+## Bridge-to-main constraints
+
+The bridge is not yet designed, but it is a required early milestone and the
+mechanism that makes every later migration slice feasible. Derive it from
+enough closure evidence to avoid baking in the wrong boundary; do not postpone
+it until every parity question or high-level interface is complete. Preserve
+these constraints:
+
+- it must land on current `main`, not make `main` adopt the reconstructed
+  Dendritic tree wholesale;
+- legacy configurations must continue to work while individual lanes move;
+- new virtual module namespaces must be introducible alongside old
+  `darwinModules`, `homeModules`, and `nixosModules` exports;
+- avoid requiring `ezConfigs` for new configurations;
+- do not delete old modules until every consuming closure has moved;
+- generated `flake.nix`/`flake.lock` changes must be isolated and explainable;
+- commit boundaries should follow dependency cones and leave the flake
+  evaluable;
+- prefer a substrate/registry bridge followed by low-level HM lanes, profiles,
+  system adapters, and host roots—not a cherry-pick of historical reconstruction
+  commits whose context assumes the blanked tree;
+- record old-to-new behavior decisions so future ports are closure migrations,
+  not archaeology repeats.
+
+Success means ordinary work can return to a trunk-based rhythm: introduce or
+polish one capability cone, integrate it with one or more real consumers, verify
+it alongside untouched legacy closures, and merge it to `main`. A bridge that
+still requires carrying a broad shadow tree, periodically rebasing the entire
+`dendritic` rewrite, or deleting legacy exports before their consumers move is
+not a successful bridge.
+
+A likely sequence, subject to evidence, is:
+
+1. Dendritic virtual-module/export substrate compatible with existing outputs;
+2. inputs/Nixpkgs/Home Manager foundations required by the HM cone;
+3. identity and low-level shell program interfaces;
+4. shell backends and explicit integrations;
+5. editor/terminal capabilities and standalone HM fixtures;
+6. provisional presets using `mkDefault`;
+7. Darwin owner/HM adapters and narrowly needed desktop behavior;
+8. remote-builder interface/backend/guest;
+9. `nixbook-pro` root;
+10. later remote, application, desktop, and other machine lanes.
+
+Do not treat this likely sequence as approved implementation detail until the
+audit and dependency graph establish exact commits.
+
+## Working protocol for future agents
+
+At the start of every continuation:
+
+1. read this file completely;
+2. inspect `git status --short --branch`, branches, worktrees, and recent logs;
+3. treat current files and evaluated outputs as authoritative over historical
+   statements in this handoff;
+4. update stale coordinates in this file when making a durable architectural
+   commit;
+5. resume the closure ledger before inventing a plan from memory.
+
+While analyzing:
+
+- use `git show main:path` to inspect legacy sources without switching branches;
+- use `rg`/`git grep` to trace imports and option assignments;
+- inspect the actual old root wiring, including invisible framework injection;
+- distinguish static source similarity from evaluated parity;
+- record accepted changes separately from accidental omissions;
+- avoid changing exploratory interfaces merely to make the audit cleaner.
+
+Before editing:
+
+- produce the exact transitive dependency cone for the intended slice;
+- check for user changes and preserve them;
+- explain whether the edit advances interface severability, backend
+  replaceability, closure lightness, composability, parity, or bridgeability;
+- reject changes that merely reproduce the old bundle under new names.
+
+Before committing:
+
+- inspect the diff and commit only the intended slice;
+- run evaluation/build checks proportional to the closure changed;
+- include negative closure tests for backend disablement where relevant;
+- do not claim broad parity from `nix flake check --no-build` alone;
+- update this handoff when a decision, status, branch coordinate, or next step
+  materially changes.
+
+## Immediate next work
+
+1. Finish the HM program-by-program behavioral ledger listed above.
+2. Evaluate the old and new `nixbook-pro` configurations where feasible and
+   capture normalized option/output diffs, separating dependency-version drift
+   from architectural changes.
+3. Complete Linux-builder parity and independent guest evaluation.
+4. Inventory remote definitions by intent so a capability interface can be
+   designed later; do not copy `krad246.remotes.*` wholesale.
+5. Audit the current HM module graph for implicit activation and unstable-input
+   evaluation leaks.
+6. Define standalone HM composition/closure tests.
+7. From the minimum sufficient evidence, write the concrete coexistence bridge
+   and commit graph; do not wait for exploratory app/browser/dock APIs to settle.
+8. Implement the bridge on current `main` as a mandatory early deliverable and
+   immediately begin landing the HM capability cone through it.
+
+The key mental model is: this is not a file migration, a naming cleanup, or a
+large rebase. It is the incremental extraction and landing of composable
+capability vTables and their derived backends, proven through the real closure
+of a machine.

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -14,23 +14,29 @@ later sessions can port coherent slices from `dendritic` without repeating its
 structural-rebase problem. Continue the epic until the remaining machine
 closures have been migrated.
 
-The immediate sequence is:
+The coexistence bridge is landed on `main` at `c116a095`. It consumes the
+operationally frozen Dendritic flake and exposes its module registries beneath
+`self.dendritic`, so
+later slices can port capability cones without rebasing the reconstructed
+branch or deleting unrelated legacy closures. The `dendritic` source is frozen
+at `0846de2f` and tagged `dendritic-suspended-2026-08-12`; treat it as a
+predecessor/source archive while migration proceeds from current `main`. The
+lock file pins the exact commit; the input URL names the protected branch rather
+than the immutable tag, so branch protection is part of the freeze guarantee.
 
-1. finish a behavioral and architectural diff of the complete old and new
-   `nixbook-pro` closures;
-2. polish the low-level Home Manager experience until it is independently
-   landable and production quality;
-3. derive an explicit dependency graph and concrete commit plan;
-4. create a bridge commit on `main` that permits legacy and Dendritic structures
-   to coexist;
-5. port capability lanes and machine closures in coherent, verified commits.
+The immediate sequence is now:
 
-The coexistence bridge is mandatory and urgent, not an optional cleanup after
-the HM design is perfected. The migration cannot land without converting this
-long-lived feature-branch effort into trunk-based incremental work. Do enough
-closure analysis to design the bridge correctly, then land the bridge on
-current `main` and route the polished HM slice through it. Do not continue
-accumulating a second unmergeable architecture on `dendritic`.
+1. completely port the standalone Home Manager `. #base` logical closure;
+2. prove that same base module on aarch64-darwin and x86_64-linux and through
+   both standalone and system-integrated consumers;
+3. delete legacy `generic-linux` once its full behavior is represented by the
+   cross-platform base and platform dispatch; current HM uses
+   `targets.genericLinux`, while the final capability-level Linux/Darwin target
+   vocabulary remains to be settled by the port;
+4. port Dendritic's redesigned flake-policy implementation instead of growing
+   main's legacy checks/hooks into a competing architecture;
+5. continue porting capability lanes and machine closures in coherent,
+   independently mergeable commits.
 
 The current highest-value landing hypothesis is a complete, correct, general,
 and severable Home Manager substrate with two immediate consumers:
@@ -286,29 +292,51 @@ desired replacement. None is currently known to fit this architecture well.
 `import-tree` currently provide generated-input and Dendritic module discovery,
 but host composition belongs to the project's own capability modules.
 
+### Flake policy and output surface
+
+Dendritic's redesigned flake-level policy is the durable implementation to
+port. Do not elaborate `main`'s legacy checks and hook machinery into a new
+general framework during migration. Preserve existing behavior, add only
+narrow and conspicuously disposable bridge glue where an immediate proof is
+needed, then replace that glue by consuming the Dendritic policy interface.
+
+A large, expressive flake output surface is desirable. The architectural
+problem is not output count; it is accidental declaration, ownership,
+composition, and consumption semantics. Retain or rebuild useful outputs behind
+the redesigned Dendritic module/policy structure. Never use schema shrinkage as
+a proxy for architectural quality.
+
+For the initial HM base port, retain `check-flake` and `check-flake-file`
+unchanged. A separate temporary `realize-dendritic-hm-base` pre-push hook may
+refer symbolically to `config.checks.dendritic-hm-base.drvPath`, discard its
+string context so hook installation does not realize it, and invoke the wrapped
+Nix distribution supplied by the devshell. Delete this hook when the HM/policy
+port supersedes it. Do not replace it with `nix flake check`, `nix build
+.#base`, or a generalized map over the checks namespace.
+
 ## Branch topology and migration hazard
 
-At the time this handoff was written:
+Current durable coordinates as of 2026-08-12:
 
-- working branch: `dendritic` at `5940c9bf` before this handoff commit;
-- remote tracking branch: `origin/dendritic` at the same commit;
-- `main` at `315488c2` in the primary repository branch listing;
-- a separate worktree at `./main` is on `general-longstanding-cleanup` at
-  `6e2ecfb4` and must not be mistaken for the `main` branch;
-- merge base between `main` and `dendritic`: `f851783b`;
-- `dendritic` was reconstructed through roughly one hundred small sequential
-  commits, beginning with `Clean everything out` and rebuilding the flake and
-  modules from a blank baseline.
+- frozen predecessor branch: `dendritic` at `0846de2f`;
+- frozen tag: `dendritic-suspended-2026-08-12`;
+- bridge landed on `main`: `c116a095` (source bridge commit `b341ba3c`);
+- current main-based HM migration branch: `dendritic-hm-foundation` (the name is
+  historical; the public module/interface name is `base`, never `foundation`);
+- initial cross-platform HM base commit: `7ba2dae3`;
+- the Dendritic branch was reconstructed through roughly one hundred small
+  sequential commits, beginning with `Clean everything out` and rebuilding the
+  flake and modules from a blank baseline.
 
 Always re-check these facts. They are historical coordinates, not permanent
 truth. Use `git status --short --branch`, `git branch -vv`, `git worktree list`,
 and `git merge-base main dendritic` before acting.
 
-The branches also differ in dependency era. Current `main` has moved to 26.05
-inputs in its generated flake, while `dendritic` currently uses 25.11 for
-Nixpkgs, Home Manager, and nix-darwin. Never treat lockfiles or generated
-`flake.nix` as mechanically interchangeable. Do not solve this with a giant
-rebase. The bridge must make coexistence and incremental ports possible.
+The branches also differ in dependency era. Current `main` uses 26.05 inputs,
+while frozen `dendritic` uses 25.11 for Nixpkgs, Home Manager, and nix-darwin.
+Never treat lockfiles or generated `flake.nix` as mechanically interchangeable.
+Do not solve this with a giant rebase. The landed predecessor bridge exists to
+make coexistence and incremental ports possible.
 
 The Dendritic branch's broad diff (previously measured as 475 files, about 6,374
 insertions and 12,402 deletions) is a consequence of reconstruction, not a
@@ -727,11 +755,8 @@ All of these remain required unless the owner explicitly revises them:
 
 ## Bridge-to-main constraints
 
-The bridge is not yet designed, but it is a required early milestone and the
-mechanism that makes every later migration slice feasible. Derive it from
-enough closure evidence to avoid baking in the wrong boundary; do not postpone
-it until every parity question or high-level interface is complete. Preserve
-these constraints:
+The bridge landed on `main` at `c116a095`. Preserve these constraints as later
+ports extend it:
 
 - it must land on current `main`, not make `main` adopt the reconstructed
   Dendritic tree wholesale;
@@ -749,18 +774,48 @@ these constraints:
 - record old-to-new behavior decisions so future ports are closure migrations,
   not archaeology repeats.
 
-Success means ordinary work can return to a trunk-based rhythm: introduce or
+Success means ordinary work proceeds in a trunk-based rhythm: introduce or
 polish one capability cone, integrate it with one or more real consumers, verify
 it alongside untouched legacy closures, and merge it to `main`. A bridge that
 still requires carrying a broad shadow tree, periodically rebasing the entire
 `dendritic` rewrite, or deleting legacy exports before their consumers move is
 not a successful bridge.
 
-A likely sequence, subject to evidence, is:
+### Operational trunk migration loop
 
-1. Dendritic virtual-module/export substrate compatible with existing outputs;
-2. inputs/Nixpkgs/Home Manager foundations required by the HM cone;
-3. identity and low-level shell program interfaces;
+Apply the bridge repeatedly as a consumer-driven closure migration:
+
+1. choose the smallest coherent capability cone needed by a real consumer,
+   starting with the complete standalone HM `. #base` logical closure;
+2. consume the frozen predecessor's virtual interfaces through `self.dendritic`
+   while defining main-owned replacements at the same registry boundary;
+3. reconstitute the target consumer from capability imports and prove behavior,
+   backend replaceability, and derivation closure on the current main-based
+   branch;
+4. deactivate or remove only the corresponding legacy `ezConfigs` code path and
+   old modules whose consumer count has reached zero; unrelated legacy hosts
+   and closures remain live;
+5. once a capability cone is proven, internalize/move its required module
+   sources into the current tree so main no longer depends on the predecessor
+   for that cone;
+6. merge the independently coherent slice to main and select the next consumer
+   cone rather than accumulating a second long-lived integration branch;
+7. repeat until `ezConfigs`, predecessor registries/input, and compatibility
+   adapters have no consumers;
+8. delete `ezConfigs`, the Dendritic bridge/input, temporary realization hooks,
+   and frozen-branch migration machinery as final cleanup—not before.
+
+Large deletions are therefore amortized by consumer migration. Never mirror the
+feature branch's original mass deletion onto main, and never require Dendritic
+to rebase over ongoing main development. Near the endpoint, the accumulated
+main tree becomes the successor architecture and the frozen branch ceases to be
+a dependency; this is a sequence of source-ownership transfers, not a final
+giant branch merge.
+
+A likely continuation sequence, subject to evidence, is:
+
+1. finish the main-owned cross-platform HM `base` and standalone shell;
+2. identity and low-level shell program interfaces;
 4. shell backends and explicit integrations;
 5. editor/terminal capabilities and standalone HM fixtures;
 6. provisional presets using `mkDefault`;
@@ -947,6 +1002,44 @@ static context cost; expand canonical detail dynamically. The hash is an
 integrity/version proxy, not a magical semantic compression: a new agent must
 read the routed source to recover meaning.
 
+#### Write-through cache and cross-machine continuation
+
+Use a deliberately simple single-writer, write-through coherence model. The
+repository bundle is authoritative memory; local Codex project-charter files
+are disposable read caches. There is no peer-to-peer merge protocol and no
+cache may become an independent source of truth.
+
+For every durable architectural memory write:
+
+1. edit `.agents/dendritic/context.md`, its routes, template, or supporting
+   bundle files first;
+2. run `.agents/dendritic/context.sh refresh`, which regenerates the proxy hash,
+   root `AGENTS.md`, manifest, and local project-charter mirrors;
+3. run `verify` and `verify-cache`;
+4. commit canonical and generated repository files together with the embodying
+   implementation, or in an immediate context-only commit;
+5. push the commit before relying on another machine/model to remember it.
+
+If an agent or human has already mutated a local cache file, do not run a sync
+that overwrites it blindly. Diff it against canonical context, reconcile every
+durable non-stale fact into the appropriate canonical sections, then refresh.
+Cache-only changes are dirty, non-durable writes and must not survive the turn.
+
+To continue on another computer or with another Codex instance:
+
+1. clone or pull the repository branch containing the newest context commit;
+2. read root `AGENTS.md` and run `.agents/dendritic/context.sh verify`;
+3. run `.agents/dendritic/context.sh sync-cache` followed by `verify-cache`;
+4. run `.agents/dendritic/context.sh full` before architectural work, or read
+   only routed sections for bounded implementation after full context has been
+   established;
+5. inspect current Git/evaluation state because recorded coordinates are
+   historical evidence, not a substitute for the live tree.
+
+This is write-through, not eventual consistency: a decision that affects
+subsequent work is synchronized before that work continues. Commit + push is
+the publication boundary; merely changing model memory or a local cache is not.
+
 ### Mandatory architectural decision synchronization
 
 Conversation is not the durable source of truth. Whenever the owner makes a
@@ -976,10 +1069,10 @@ interpretation depends on it:
    note while leaving stale instructions elsewhere;
 4. preserve relevant historical evidence and label the new status/decision;
    distinguish a changed owner decision from a newly discovered fact;
-5. run `.agents/dendritic/context.sh refresh` to regenerate the manifest and
-   root `AGENTS.md` proxy hash;
-6. run `.agents/dendritic/context.sh verify`, route-expansion checks, shellcheck,
-   and `git diff --check`;
+5. run `.agents/dendritic/context.sh refresh` to regenerate the manifest, root
+   `AGENTS.md` proxy hash, and local cache mirrors;
+6. run `.agents/dendritic/context.sh verify`, `verify-cache`, route-expansion
+   checks, shellcheck, and `git diff --check`;
 7. inspect the canonical and generated diffs for accidental loss;
 8. commit the bundle update with the implementation that embodies the decision,
    or make an immediate context-only commit when implementation will follow in
@@ -1034,20 +1127,21 @@ Before committing:
 
 ## Immediate next work
 
-1. Finish the HM program-by-program behavioral ledger listed above.
-2. Evaluate the old and new `nixbook-pro` configurations where feasible and
-   capture normalized option/output diffs, separating dependency-version drift
-   from architectural changes.
-3. Complete Linux-builder parity and independent guest evaluation.
-4. Inventory remote definitions by intent so a capability interface can be
-   designed later; do not copy `krad246.remotes.*` wholesale.
-5. Audit the current HM module graph for implicit activation and unstable-input
-   evaluation leaks.
-6. Define standalone HM composition/closure tests.
-7. From the minimum sufficient evidence, write the concrete coexistence bridge
-   and commit graph; do not wait for exploratory app/browser/dock APIs to settle.
-8. Implement the bridge on current `main` as a mandatory early deliverable and
-   immediately begin landing the HM capability cone through it.
+1. Finish total behavioral porting of `. #base`, using the program-by-program HM
+   ledger and explicit owner decisions rather than copying legacy bundles.
+2. Keep the evaluated cross-platform base checks meaningful; during this
+   migration, the temporary pre-push hook realizes their exact selected
+   derivation through wrapped Nix while legacy `check-flake` remains intact.
+3. Prove standalone and system-integrated HM consumers, then delete
+   `generic-linux` when no behavior remains unique to it.
+4. Port the Dendritic flake-policy interface, retaining a rich output surface
+   while redesigning declaration/ownership/composition semantics.
+5. Continue normalized old/new `nixbook-pro` behavioral diffs, Linux-builder
+   parity, and remote-definition intent inventory as their dependency lanes
+   become relevant.
+6. Audit implicit backend activation, input forcing, and derivation closure at
+   capability boundaries; reuse established invariants rather than relitigating
+   downstream symbol validity.
 
 The key mental model is: this is not a file migration, a naming cleanup, or a
 large rebase. It is the incremental extraction and landing of composable

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -1040,6 +1040,15 @@ This is write-through, not eventual consistency: a decision that affects
 subsequent work is synchronized before that work continues. Commit + push is
 the publication boundary; merely changing model memory or a local cache is not.
 
+Long-running agent sessions have intermittently exhausted file descriptors.
+Until the leak is fixed, periodically checkpoint durable progress through the
+normal write-through path—canonical bundle first, then refresh, verify, commit,
+and push—so a cache flush or process restart has a recent recovery point. Do
+this after meaningful architectural/ledger milestones and before any planned
+flush; do not let an extended implementation session accumulate important
+context only in conversation or local caches. A cache flush is operational
+recovery, not publication, and does not replace the canonical checkpoint.
+
 ### Mandatory architectural decision synchronization
 
 Conversation is not the durable source of truth. Whenever the owner makes a

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -1069,6 +1069,12 @@ flush; do not let an extended implementation session accumulate important
 context only in conversation or local caches. A cache flush is operational
 recovery, not publication, and does not replace the canonical checkpoint.
 
+`nix run .#agent-checkpoint` is the stable mechanical entry point. Keep that
+public command generic: today it delegates to the Dendritic bundle's
+`checkpoint` primitive, but future agent-maintained internal documentation may
+replace or extend that storage without renaming the lifecycle action. A matching
+Just command namespace is a possible convenience layer, not current scope.
+
 ### Mandatory architectural decision synchronization
 
 Conversation is not the durable source of truth. Whenever the owner makes a

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -24,6 +24,19 @@ predecessor/source archive while migration proceeds from current `main`. The
 lock file pins the exact commit; the input URL names the protected branch rather
 than the immutable tag, so branch protection is part of the freeze guarantee.
 
+“Frozen” is an operational stability state, not a ban on correcting code the
+predecessor still owns. When migration uncovers such a defect, temporarily thaw
+`dendritic`, repair and verify the authoritative implementation, update the
+freeze coordinate/tag and bridge pin, then freeze it again. Do not internalize
+or duplicate a capability merely to carry its repair; source-ownership transfer
+is a separate landing justified by a coherent consumer cone.
+
+The active main-based migration branch owns the sole context-policy bundle.
+The predecessor must not retain a divergent `.agents/dendritic` bundle or root
+proxy after its next re-freeze. A repair performed in its worktree follows the
+active branch's policy through that worktree/revision, then commits only the
+predecessor source change and removal of stale policy copies.
+
 The immediate sequence is now:
 
 1. completely port the standalone Home Manager `. #base` logical closure;
@@ -324,9 +337,8 @@ Current durable coordinates as of 2026-08-12:
 - current main-based HM migration branch: `dendritic-hm-foundation` (the name is
   historical; the public module/interface name is `base`, never `foundation`);
 - initial cross-platform HM base commit: `7ba2dae3`;
-- main-owned Home Manager input-registry cone: the generic
-  source/sysroot/search-path interpreter and HM adapter no longer depend on the
-  frozen predecessor implementation;
+- the Home Manager input-registry cone remains predecessor-owned while its
+  canonical-path defect is repaired and the source is re-frozen;
 - the Dendritic branch was reconstructed through roughly one hundred small
   sequential commits, beginning with `Clean everything out` and rebuilding the
   flake and modules from a blank baseline.
@@ -647,8 +659,8 @@ evidence rather than filename inference.
 | HM Agenix module/package | accepted removal | Do not port it in the thin HM slice. RBW remains selected. |
 | Cachix binary-cache policy | accepted omission for thin slice | Main user Nix settings include krad246 Cachix; Dendritic user Nix settings do not. Old broad daemon/cache policy need not block first HM landing. |
 | broad per-user Nix policy | accepted omission for thin slice | Main evaluates many performance, sandbox, retention, timeout, and cache settings; Dendritic HM evaluates only `experimental-features = [nix-command flakes]` through the registry. |
-| input flake registry | architecturally superseded/win; main-owned | Both expose registries. The migration branch now owns the generic configurable input-registry source and locked/unlocked behavior instead of consuming that cone from the frozen predecessor. Cross-platform standalone checks prove managed, unlocked HM registries and required Nix features. |
-| registry filesystem projection | changed, capability available; main-owned | Main installs `~/nix/path/*` links unconditionally via `home-link-registry`. The migration branch now owns `input-registry.sysroot.install` and optional search-path projection, both disabled for the base consumers. Public sysroot paths are canonicalized without the frozen implementation's `/./` artifact. Selection policy remains to decide; architecture is settled. |
+| input flake registry | architecturally superseded/win; predecessor-owned | Both expose registries. Dendritic replaces old `flake-registry` with the generic configurable input-registry source and locked/unlocked behavior. Preserve that design and repair it at its authoritative source until an intentional ownership-transfer landing. |
+| registry filesystem projection | changed, capability available | Main installs `~/nix/path/*` links unconditionally via `home-link-registry`. Dendritic has `input-registry.sysroot.install` and optional search-path projection, currently disabled for this consumer. Its public absolute path exposed a noncanonical `/./` artifact; fix this in Dendritic and re-freeze rather than duplicating the cone into the bridge. Selection policy remains to decide. |
 | dotfiles link/sync | accepted removal | Do not port the mutable synchronization/link behavior. |
 | XDG | changed | Main evaluates `xdg.enable=true`; Dendritic evaluates false, while both prefer XDG directories. Likely foundation parity item. |
 | manuals | changed | Effective Main: HTML false (Zen override), JSON true. Dendritic: HTML false, JSON false. Decide general HM manual policy independently of browser integration. |
@@ -814,6 +826,11 @@ to rebase over ongoing main development. Near the endpoint, the accumulated
 main tree becomes the successor architecture and the frozen branch ceases to be
 a dependency; this is a sequence of source-ownership transfers, not a final
 giant branch merge.
+
+Do not confuse source repair with source-ownership transfer. Fix a defect in a
+still-predecessor-owned capability through controlled thaw/re-freeze; transfer
+that capability only when its consumer cone, boundary proofs, and commit scope
+independently justify internalization.
 
 A likely continuation sequence, subject to evidence, is:
 

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -754,6 +754,61 @@ too broadly, stop treating it as established. Surface the conflict to the owner
 when it affects requirements, refine it, synchronize the bundle, and update its
 proof obligations.
 
+### Proof-carrying architecture and validation budget
+
+The purpose of a sound architecture is partly to make downstream work obvious
+and cheap. Once an invariant is established at the correct boundary, treat it
+as a reusable proof premise. Do not repeatedly relitigate that premise at every
+consumer, call site, or port.
+
+Canonical example: a family of Nix repositories consumes a platform repository
+through a base-derived package set and ordered overlay composition. If the
+platform contract guarantees that a symbol is present in the base or a shared
+overlay, and overlays in the supported chain extend/override without deleting
+that symbol, then the symbol is valid for downstream `callPackage` scopes. Do
+not repeatedly search every consumer to ask whether it exists. The composition
+relationship is the proof.
+
+Apply the same reasoning to Dendritic module work:
+
+- a consumer importing a declared virtual interface may rely on that interface;
+- a preset importing a backend may rely on its declared options;
+- a generic module proven applicable to HM and system contexts need not be
+  re-proven at every consumer;
+- an input guaranteed by the substrate/follows graph need not be rediscovered
+  at every module;
+- a backend replacement test established for an interface should become a
+  reusable gate rather than a repeated design debate.
+
+Validation effort belongs at boundaries and invalidation events. Revalidate an
+established premise only when one of these occurs:
+
+- base/package-set/platform source changes in a way relevant to the contract;
+- overlay ordering or composition changes;
+- an overlay replaces a containing attribute set non-monotonically, uses
+  `removeAttrs`, or otherwise may remove the guaranteed symbol;
+- a consumer stops using the supported platform-derived path;
+- module import/applicability rules change;
+- an input follow/deduplication relationship changes;
+- direct evaluation/build evidence contradicts the invariant;
+- the owner explicitly asks to reopen the invariant.
+
+Absent an invalidator, land straightforward code using the proven premise. Do
+not spend context, commands, or owner attention validating facts the
+architecture already guarantees. This is not permission to skip acceptance
+tests for new boundaries or behavior; it is a rule against duplicating proof
+after the relevant boundary has already supplied it.
+
+When defining an invariant, record its invalidators along with its proof
+obligation. This lets future agents cheaply decide whether existing evidence is
+still applicable. Prefer one strong substrate/interface test over many weak
+consumer-level existence checks.
+
+The target steady state is intentionally low-friction: most routine ports
+should follow recorded invariants mechanically, consume little context, require
+no architectural re-debate, and land correctly with only checks at genuinely
+changed boundaries.
+
 ### Evolving the context root filesystem
 
 Treat `.agents/dendritic/` as a content-addressed context root filesystem. It is

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -1106,17 +1106,19 @@ tools and immutable logic; late-bind mutable workspace locations and recovery
 inputs. Nix applications should capture executables, libraries, and exact script
 implementations through typed derivations/store paths, but must not capture an
 immutable source-store copy as the writable checkout. Resolve mutable roots in
-this order: explicit command argument, explicit environment override such as
-`FLAKE_ROOT`, then an invocation-local fallback such as `$PWD`/ancestor
-discovery. Validate the selected root, expected markers, bundle contents, and
-root/bundle coherence before mutation.
+this order: explicit command argument, then an invocation-local fallback such as
+the live script location or `$PWD`/ancestor discovery. Use an environment
+override only when the tool's actual mutable-state contract requires
+coordination with external shell state; do not inherit one merely because a
+devshell exports it. Validate the selected root, expected markers, bundle
+contents, and root/bundle coherence before mutation.
 
 Keep the underlying recovery primitive directly runnable with a baseline shell
 and explicit arguments when `direnv`, the development shell, or repository PATH
 setup is broken. Nix apps and Just recipes are typed/convenient front doors over
 that primitive, not its only execution path. Ambient environment is an override
-and recovery seam for mutable inputs, not a substitute for statically declaring
-ordinary tool dependencies.
+and recovery seam only for tools that deliberately support it, not a substitute
+for statically declaring ordinary tool dependencies or local target discovery.
 
 Checkpoint/propagation work may run in a bounded sub-agent while the primary
 agent continues an independent implementation lane. Treat the canonical bundle

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -324,6 +324,9 @@ Current durable coordinates as of 2026-08-12:
 - current main-based HM migration branch: `dendritic-hm-foundation` (the name is
   historical; the public module/interface name is `base`, never `foundation`);
 - initial cross-platform HM base commit: `7ba2dae3`;
+- main-owned Home Manager input-registry cone: the generic
+  source/sysroot/search-path interpreter and HM adapter no longer depend on the
+  frozen predecessor implementation;
 - the Dendritic branch was reconstructed through roughly one hundred small
   sequential commits, beginning with `Clean everything out` and rebuilding the
   flake and modules from a blank baseline.
@@ -644,8 +647,8 @@ evidence rather than filename inference.
 | HM Agenix module/package | accepted removal | Do not port it in the thin HM slice. RBW remains selected. |
 | Cachix binary-cache policy | accepted omission for thin slice | Main user Nix settings include krad246 Cachix; Dendritic user Nix settings do not. Old broad daemon/cache policy need not block first HM landing. |
 | broad per-user Nix policy | accepted omission for thin slice | Main evaluates many performance, sandbox, retention, timeout, and cache settings; Dendritic HM evaluates only `experimental-features = [nix-command flakes]` through the registry. |
-| input flake registry | architecturally superseded/win | Both expose registries. Dendritic replaces old `flake-registry` with the generic configurable input-registry source and locked/unlocked behavior. Preserve Dendritic design. |
-| registry filesystem projection | changed, capability available | Main installs `~/nix/path/*` links unconditionally via `home-link-registry`. Dendritic has a general `input-registry.sysroot.install` projection and optional search-path projection, currently disabled for this consumer. Selection policy remains to decide; architecture is settled. |
+| input flake registry | architecturally superseded/win; main-owned | Both expose registries. The migration branch now owns the generic configurable input-registry source and locked/unlocked behavior instead of consuming that cone from the frozen predecessor. Cross-platform standalone checks prove managed, unlocked HM registries and required Nix features. |
+| registry filesystem projection | changed, capability available; main-owned | Main installs `~/nix/path/*` links unconditionally via `home-link-registry`. The migration branch now owns `input-registry.sysroot.install` and optional search-path projection, both disabled for the base consumers. Public sysroot paths are canonicalized without the frozen implementation's `/./` artifact. Selection policy remains to decide; architecture is settled. |
 | dotfiles link/sync | accepted removal | Do not port the mutable synchronization/link behavior. |
 | XDG | changed | Main evaluates `xdg.enable=true`; Dendritic evaluates false, while both prefer XDG directories. Likely foundation parity item. |
 | manuals | changed | Effective Main: HTML false (Zen override), JSON true. Dendritic: HTML false, JSON false. Decide general HM manual policy independently of browser integration. |

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -1155,6 +1155,14 @@ variables. Prefer explicit arguments, structural location, or typed inputs over
 reading ambient bus values; stale environment inherited from another devshell
 or worktree must not redirect bootstrap or mutation targets.
 
+The repository currently uses manual nix-direnv reloads deliberately. Automatic
+reload has caused persistent reload churn, so bootstrap success means reaching
+the valid manual-reload boundary; do not force a reload on every shell entry.
+Lorri is an exploratory asynchronous publisher of richer devshell state and is
+useful but not yet a settled replacement. Preserve the current manual contract
+and revisit reload/publisher behavior in a separate lane rather than coupling it
+to bootstrap or hook-installation fixes.
+
 Checkpoint/propagation work may run in a bounded sub-agent while the primary
 agent continues an independent implementation lane. Treat the canonical bundle
 as single-writer state: delegate either the complete checkpoint operation or

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -655,6 +655,124 @@ audit and dependency graph establish exact commits.
 
 ## Working protocol for future agents
 
+### Contractor relationship and questioning style
+
+Treat the repository owner as the boss/product owner and the active agent as a
+senior implementation contractor. The owner sets requirements, priorities,
+architectural intent, and which behavioral differences are accepted. The agent
+is responsible for investigation, technical judgment, implementation quality,
+verification, and maintaining the durable context system.
+
+Do not silently fill genuine requirement ambiguity with a convenient technical
+choice. Ask questions whenever different plausible answers would change:
+
+- a capability boundary or public virtual namespace;
+- whether behavior is preserved, removed, or redesigned;
+- which backend or preset is selected;
+- the scope/order of a landing slice;
+- a compatibility or coexistence promise;
+- an invariant, acceptance gate, or meaning of completion;
+- a destructive or difficult-to-reverse migration step.
+
+Ask as many questions as needed to remove those ambiguities. Questions are not
+a substitute for engineering work: first inspect the repository, evaluate the
+relevant closures, and narrow uncertainty. Present each question with:
+
+1. the concrete evidence that created it;
+2. the exact decision being requested;
+3. the viable alternatives;
+4. consequences for behavior, closure, architecture, and landing order;
+5. the agent's recommendation and why;
+6. whether work can continue independently while awaiting the answer.
+
+Do not ask the owner to rediscover facts available in the tree. Do not bury a
+material choice in a long report or phrase it as a fait accompli. Conversely,
+do not stop for inconsequential implementation details that are reversible and
+fully determined by recorded invariants.
+
+When the owner corrects an interpretation, treat the correction as new
+authoritative requirements input. Reflect it back precisely, run the mandatory
+decision-sync protocol, then revisit any analysis or plan whose conclusions
+depended on the old interpretation.
+
+The desired feedback loop is:
+
+```text
+owner requirement or correction
+          ↓
+agent gathers/updates authoritative evidence
+          ↓
+agent states invariants, options, consequences, and recommendation
+          ↓
+owner decides unresolved requirement questions
+          ↓
+agent synchronizes the committed context bundle
+          ↓
+agent implements and verifies against explicit proof obligations
+          ↓
+agent reports evidence, remaining questions, and next selectable lanes
+          ↺
+```
+
+### Reasoning about invariants
+
+Before designing or changing a capability, extract its invariants in plain
+language. An invariant is not a preference or a module name; it is a property
+that must remain true across implementations and compositions. For each one,
+record:
+
+- scope: which interface, backend, integration, preset, or consumer it governs;
+- rationale: what architectural/user requirement it protects;
+- positive examples and counterexamples;
+- proof obligation: the evaluation, build, closure inspection, or replacement
+  test that demonstrates it;
+- override policy: whether a preset/host may weaken it, and how explicitly;
+- status: proposed, owner-confirmed, implemented, or verified.
+
+Reason from invariants toward module boundaries, not from existing files toward
+post-hoc justifications. Test proposed interfaces with at least these questions:
+
+- Can a consumer express intent without naming a backend?
+- Can a second backend satisfy the contract without changing the consumer?
+- Can either endpoint of an integration exist without the other?
+- Does importing the interface install or force an implementation?
+- Can presets select defaults without preventing caller overrides?
+- Can both immediate consumers—integrated and standalone HM where relevant—use
+  the same contract?
+- What exact output would falsify the claimed closure property?
+
+If a discovered counterexample invalidates an invariant or shows it was stated
+too broadly, stop treating it as established. Surface the conflict to the owner
+when it affects requirements, refine it, synchronize the bundle, and update its
+proof obligations.
+
+### Evolving the context root filesystem
+
+Treat `.agents/dendritic/` as a content-addressed context root filesystem. It is
+intended to contain enough authoritative state, routing, procedures, and
+evidence that an unfamiliar successor can execute it like a program and recover
+the project's working model without keeping the entire history in memory.
+
+As the owner teaches a new collaboration preference, reasoning method,
+architectural rule, vocabulary term, or review expectation:
+
+1. determine whether it is durable/general or only local to the current task;
+2. for durable guidance, identify its canonical section or add a narrowly named
+   section and lazy route;
+3. connect it to the decision-sync protocol and any affected working steps;
+4. add executable checks or proof templates when prose can be mechanized;
+5. remove or rewrite superseded guidance so the rootfs is internally coherent;
+6. refresh, verify, and commit the new proxy hash;
+7. exercise the route from a cold-reader perspective: it must say what to read,
+   what to do, what evidence to collect, when to ask, and how to persist the
+   result.
+
+Do not optimize the canonical rootfs for minimum byte count at the expense of
+losslessness. Optimize the always-loaded proxy and route selection for low
+static context cost; expand canonical detail dynamically. The hash is an
+integrity/version proxy, not a magical semantic compression: a new agent must
+read the routed source to recover meaning.
+
 ### Mandatory architectural decision synchronization
 
 Conversation is not the durable source of truth. Whenever the owner makes a

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -355,6 +355,12 @@ maxJobs, TERM, bottom, coredumps, and protocol.
   capability; it was initially narrowed out because of porting friction.
 - Profiles are presets and may compose through imports and enable/default
   declarations.
+- The old broad per-user Nix daemon/cache policy may be omitted from the
+  thinnest HM landing slice. Its absence does not block that slice.
+- The Dendritic input-registry architecture is settled progress and must be
+  preserved: its source/registry, filesystem sysroot projection, optional
+  legacy search-path projection, and cross-context generic interface are a
+  substantial improvement over the old registry plus home-link modules.
 
 ## Explicitly unfinished or exploratory areas
 
@@ -409,11 +415,11 @@ Status meanings:
 | trusted owner | preserved | Host sets `nix.settings.trusted-users`. |
 | Touch ID for sudo | preserved | Set by host. |
 | nixbld GID 350 | preserved | Current `darwin.nix`. |
-| system Agenix module and custom Agenix package | missing | `darwin.secrets` only bridges HM RBW; it does not import `darwin.agenix` or install the prior tool. Decide desired system/HM secret capabilities. |
+| system Agenix module and custom Agenix package | missing | Evaluated Main system packages include Agenix; Dendritic does not. `darwin.secrets` only bridges HM RBW and does not import `darwin.agenix`. Decide desired system/HM secret capabilities. |
 | firewall | irrelevant | Old file contained comments only. |
-| system terminal fonts | missing | Old `fonts.packages = pkgs.krad246.term-fonts.paths`; no equivalent found in current host cone. |
+| system terminal fonts | no effective difference | Although the old source assigns `fonts.packages = pkgs.krad246.term-fonts.paths`, evaluated `fonts.packages` is empty on both configurations. The actual font difference is in the HM closure, not system fonts. |
 | HM bridge package universe | changed/unverified | Old had `useGlobalPkgs=true`, `useUserPackages=true`, `verbose=false`; new leaves global pkgs off, uses user packages, and is verbose. Audit package identity/overlays/unfree effects before choosing policy. |
-| Homebrew substrate | changed/unverified | Old imported nix-homebrew but defaulted it and Homebrew off, still added `mas` and prefix/shell declarations. Current app-store selection activates Homebrew. Compare effective behavior, not declarations. |
+| Homebrew substrate | changed, evaluated | Main has Homebrew disabled but declares Bash/Zsh brews, the six selected casks, and two MAS apps. Dendritic enables Homebrew, removes Bash/Zsh brews, and preserves the same six casks and two MAS apps. This activation/policy change is entangled with the exploratory app-store and requires later design; Nixpkgs Bash is accepted for thin slice. |
 | guest login disabled | missing | Old master-user module set `GuestEnabled=false`; current lock-screen modules are empty. |
 | console access disabled | missing | Old set `DisableConsoleAccess=true`; no current realization found. |
 | screensaver password | missing | Old set `screensaver.askForPassword=true`; current screensaver module is empty. |
@@ -422,13 +428,23 @@ Status meanings:
 | Finder settings | static match | Hidden/extensions, desktop, search scope, view, trash cleanup, path/status bars, POSIX title, folders-first are mapped. |
 | menu/dialog preferences | static match | Expanded save/print panels, table mode, visible menu bar mapped. |
 | pointer/trackpad | static match | Flat mouse acceleration, non-natural scrolling, right-click, corner/scaling values represented. |
+| keyboard basics | static match through HM dispatcher | Full keyboard access, repeat rates, text substitutions, function-key mode, window animations, and Fn usage intent are represented in the Dendritic desktop vTable/Darwin dispatcher. Evaluate generated HM Darwin defaults rather than only nix-darwin `system.defaults`, because responsibility moved layers. |
+| symbolic keyboard shortcuts | missing | Main's evaluated nix-darwin configuration contains 87 `com.apple.symbolichotkeys.AppleSymbolicHotKeys` entries. Dendritic's `desktop.input.keyboard.shortcuts` interface is empty and no equivalent mapping exists. This is a substantial unported desktop lane, not covered by the basic keyboard options. |
 | Spotlight order | static match | Same explicit ordered list exists in Darwin HM dispatcher. |
 | window manager/spaces | mostly static match | Old values represented; evaluate exact domains/types. |
 | Dock constants | mostly static match | Old autohide, magnification, tile size, corners, recents, etc. represented. |
 | Dock apps | partial | Old pinned iPhone Mirroring + Launchpad, and host prepended Zen. New defaults request logical browser, phone-mirroring, launchpad, file-manager, terminal, editor. Darwin dispatcher only maps browser/phone/launchpad, filtering unknown IDs, so effective list is Zen + phone + launchpad. Confirm ordering and whether omitted logical roles need real backends. |
 | Tailscale | static match | Darwin service enabled. |
-| Linux builder | superseded/unverified | Better architecture; perform detailed parity evaluation. |
+| Linux builder | superseded/unverified | Better architecture. Both enable ephemeral builder with maxJobs 60; Main advertises i686/x86_64/aarch64 Linux while Dendritic advertises only x86_64/aarch64. Complete guest config and decide whether i686 removal is accepted. |
 | Dullahan/Gremlin/Fortress remotes | missing | Must be redesigned as capability/backends, not copied as host bundle. |
+
+Evaluated system package placement also confirms expected accepted removals:
+Main includes Colima, the macOS container package, and Docker; Dendritic does
+not. Main includes system Agenix and Lorri; Dendritic does not. Dendritic adds
+Discord as a system Nix package. `m-cli` moves from Main's system package set to
+the Dendritic owner HM package set. Both retain Tailscale and the normal
+nix-darwin packages. The login shell changes from `/opt/homebrew/bin/bash` to
+Nixpkgs Bash as explicitly accepted.
 
 ### Applications and accepted removals
 
@@ -452,10 +468,10 @@ The current application-store design has known flaws, not migration invariants:
 Do not preserve these flaws for compatibility. Redesign after understanding
 actual machine/application lanes.
 
-### Home Manager legacy closure: required audit
+### Home Manager legacy closure: evaluated audit in progress
 
-This audit is not finished. The old `krad246` HM root sets username/home from
-the OS user, overrides Git email to `condor-janitor0e@icloud.com`, and imports:
+The old `krad246` HM root sets username/home from the OS user, overrides Git
+email to `condor-janitor0e@icloud.com`, and imports:
 
 - complete `base-home`;
 - `krad246-cachix`;
@@ -468,40 +484,72 @@ Git, Helix, LSD, terminal fonts, packages, Ripgrep, Spotify Player, Starship,
 Yazi, Zoxide, and Zsh. It also owns activation, XDG, manuals, state version, and
 dotfiles behavior.
 
-The next agent must make a row-by-row old/new ledger for at least:
+Both configurations have now been evaluated directly using current
+`dendritic` and `git+file://...?ref=main`; the following is effective-output
+evidence rather than filename inference.
 
-- identity name/username/email and the special Git email override;
-- Agenix HM module and package versus RBW capability;
-- Cachix configuration;
-- Nix settings and package universe;
-- flake registry and home/system link registries;
-- Bash behavior: vi mode, completion, VTE, Ctrl-H, reload alias, history rules,
-  `tldr`, Yazi wrapper, Kitty/FZF image preview integration;
-- Zsh behavior and whether its removal/nonselection is intentional;
-- Bat theme, extras, aliases, BATDIFF/LESSOPEN/BATPIPE behavior;
-- Bottom Linux desktop hiding;
-- Direnv/nix-direnv and per-shell integrations;
-- FD hidden/default options;
-- old FZF widgets, bindings, preview/view/edit commands, and source semantics;
-- Git identity, LFS, aliases, delta, GH credentials, Kitty integrations;
-- Helix package (`evil-helix` currently), languages, settings, keymaps, and FZF
-  editor integration;
-- LSD colors, hyperlinking, aliases, and shell integration;
-- terminal font packages and Linux fontconfig;
-- package lists, including lost/added tools (`safe-rm`, `procs`, `has`, etc.);
-- Ripgrep and ripgrep-all;
-- Spotify Player (apparently absent in current cone);
-- Starship settings and shell integration;
-- Yazi settings/keymaps/integrations;
-- Zoxide integrations;
-- Codex moved from host-local import to development preset;
-- old dotfiles sync activation and out-of-store link behavior;
-- manual HTML/JSON behavior, including old Zen manual opener behavior;
-- XDG configuration and Home Manager state version.
+| HM responsibility | Status | Evaluated/source evidence and follow-up |
+|---|---|---|
+| username/home directory | preserved | Both evaluate to `krad246` and `/Users/krad246`. |
+| identity name | preserved | Both Git configurations use `Keerthi Radhakrishnan`; Dendritic derives it from `identity.person`. |
+| special Git email | missing/decision required | Main evaluates `condor-janitor0e@icloud.com`; Dendritic evaluates `krad246@gmail.com` from flake owner metadata. Decide whether Git needs a separate identity/account slot rather than changing the person default. |
+| RBW | preserved with better interface | Enabled in both. Dendritic derives email from `identity.person` and selects platform pinentry behind `identity.secrets.backends.rbw`. |
+| HM Agenix module/package | missing | Main has Agenix in the HM package closure; Dendritic does not import HM Agenix for this user. Decide whether Agenix and RBW are separate secret capabilities rather than alternatives. |
+| Cachix binary-cache policy | accepted omission for thin slice | Main user Nix settings include krad246 Cachix; Dendritic user Nix settings do not. Old broad daemon/cache policy need not block first HM landing. |
+| broad per-user Nix policy | accepted omission for thin slice | Main evaluates many performance, sandbox, retention, timeout, and cache settings; Dendritic HM evaluates only `experimental-features = [nix-command flakes]` through the registry. |
+| input flake registry | architecturally superseded/win | Both expose registries. Dendritic replaces old `flake-registry` with the generic configurable input-registry source and locked/unlocked behavior. Preserve Dendritic design. |
+| registry filesystem projection | changed, capability available | Main installs `~/nix/path/*` links unconditionally via `home-link-registry`. Dendritic has a general `input-registry.sysroot.install` projection and optional search-path projection, currently disabled for this consumer. Selection policy remains to decide; architecture is settled. |
+| dotfiles link/sync | missing/decision required | Main has `syncDotfiles`, `switchToSpecialisation`, and dotfiles file entries. Dendritic has none. Reassess whether mutable repo synchronization belongs in managed HM at all. |
+| XDG | changed | Main evaluates `xdg.enable=true`; Dendritic evaluates false, while both prefer XDG directories. Likely foundation parity item. |
+| manuals | changed | Effective Main: HTML false (Zen override), JSON true. Dendritic: HTML false, JSON false. Decide general HM manual policy independently of browser integration. |
+| state version | version drift | Main evaluates 26.05 and Dendritic 25.11 due branch input eras. Resolve intentionally during port; do not copy one blindly. |
+| Lorri | preserved on Darwin | Disabled in both on this host. Dendritic dev preset enables it only on Linux. |
+| Bash selection | preserved | Bash enabled in both with completion, VTE, and vi mode. |
+| Bash history | changed | Main ignores `exit` and `reload`; Dendritic ignores only `exit`. Control values are semantically the same, reordered. |
+| Bash Ctrl-H binding | missing | Main explicitly unbinds Ctrl-H; Dendritic does not. |
+| Bash reload alias | missing | Main reconstructs Bash RC and reloads Direnv; Dendritic does not define it. |
+| Bash `tldr` alias | changed | Main defines executable-resolved alias; Dendritic installs `tldr` but does not define that alias. Likely harmless, verify desired UX. |
+| Bash-Yazi wrapper | preserved | Both provide `y()` with cwd-file behavior; Dendritic gates it through explicit integration. |
+| Bash integrations | architecturally improved, parity incomplete | Dendritic explicitly dispatches Direnv, FZF, LSD, Kitty, Starship, Yazi, and Zoxide. Old Kitty+FZF image-preview environment behavior is not visibly reproduced. |
+| Zsh | missing/decision required | Main enables and configures Zsh; Dendritic selected profile disables Nushell and does not enable Zsh. Determine whether Zsh remains a backend requirement or accepted removal. |
+| Bat theme | preserved | Gruvbox dark in both; Dendritic also sets terminal title. |
+| Bat extras | changed | Main includes batdiff, batgrep, batman, batpipe, batwatch, prettybat. Dendritic effective closure includes batdiff, batgrep, batman, prettybat but not batpipe/batwatch as packages. Batpipe is invoked conditionally through a Bash integration and needs closure validation. |
+| Bat aliases/environment | changed | Main aliases `cat` to `bat -pp`, resolves `brg`/`man`/`bdiff` to store executables, and sets BATDIFF/LESSOPEN/LESS/BATPIPE. Dendritic aliases `bat` to `prettybat`, keeps `brg`/`man`/`bdiff` by command name, sets BATDIFF, and delegates LESS/PAGER to its pager capability. It drops the old `cat` alias and batpipe `LESSOPEN`/`BATPIPE` environment. Decide desired composition rather than blindly restore. |
+| Bottom | preserved enablement, changed config | Enabled in both; Dendritic adds substantial settings and selects unstable. Old Linux no-display desktop entry is commented out in Dendritic and matters only to the standalone Linux consumer. |
+| Direnv/nix-direnv | preserved | Enabled in both; Dendritic makes shell integrations explicit. |
+| FD | preserved enablement, changed option | Both enabled. Main sets `hidden=false`; Dendritic adds `--hyperlink auto`. Confirm candidate semantics rather than option spelling. |
+| FZF | architecturally improved, effective config changed | Enabled in both. Dendritic factors picker sources/actions/bindings and FD/Bat/Helix integrations. Normalized output preserves Ctrl-T/Alt-C/Ctrl-R, preview, reload, multi-view, and edit behaviors. New reload commands correctly use the relevant logical source (directories reload `fd --type d`) instead of Main's shared/eval-wrapped default command. Option ordering/store versions differ. Full `programs.fzf` attrset cannot be serialized on either branch because HM exposes the removed `historyWidgetCommand` option; compare selected supported fields and generated shell environment instead. |
+| Git base settings/LFS/aliases | mostly preserved | Core settings, LFS, aliases, merge/push/rebase policy are present. Effective hash differs due email and credential integrations. |
+| Git credentials | regression/decision required | Main enables `git-credential-oauth` and GH helpers for GitHub/Gist. Dendritic evaluated Git credential map is empty because new GH identity slots default to null. Design identity slots and secret/token flow before claiming parity. |
+| Delta/Lazygit | mostly preserved, version-sensitive schema | Same core Delta flags and Lazygit preferences/keybindings are split into capabilities. Main 26.05 effective config uses `git.diffRenderer[].command`; Dendritic 25.11 uses `git.pagers[].pager`. Preserve the capability relationship but adapt its realization to the target HM/Lazygit schema during port. |
+| Helix package/default | preserved | Both enable `evil-helix` as default editor. |
+| Helix settings/keymaps | two known changes | Dendritic removes `Alt-] = nix fmt` in all modes and changes `Alt-F` from no-op to `format_selections` in normal/select. Everything else in normalized effective settings matches. Confirm changes. |
+| Helix languages | regression plus deliberate additions | Dendritic adds Nix/nixd but drops Rust, docker-compose, Bash shfmt, rust-analyzer, and systemd server declaration. More seriously, evaluated output nests language entries under `languages.language` instead of top-level `language`, suggesting an erroneous extra `languages` level in the module. Fix before HM landing. |
+| FZF-Helix edit action | structurally preserved | Both build a no-suspend Helix wrapper; Dendritic exposes it through picker action vTable. Test produced command. |
+| LSD | preserved exactly | Normalized effective configuration hashes match. |
+| terminal fonts | missing/partial | Main HM closure includes Cascadia Code, Meslo, and symbols fonts; Dendritic gets Meslo through Kitty styling only. General terminal-font capability is absent. |
+| Kitty terminal | preserved plus explicit integration | Enabled in both. Normalized effective settings, keybindings, theme, font, launch options, and shell-integration values match modulo store path. Dendritic additionally enables HM's Git integration through an explicit Git-Kitty capability relationship; Main leaves it false. |
+| base package set | changed | Main-only notable tools include `safe-rm`, `procs`, `has`; Dendritic adds a larger dev/interactive set including curl, file, jq, tree, archives, CMake/GDB/binutils, and Nix diagnostics. Classify by preset lane rather than demand exact set equality. |
+| Ripgrep + ripgrep-all | preserved | Both enabled. Dendritic integration split provides Bat behavior. |
+| Spotify Player | missing/decision required | Enabled on Main, disabled on Dendritic. Decide whether it belongs in the HM slice/profile. |
+| Starship | preserved exactly | Normalized settings hashes match; Dendritic shell integration is explicit. |
+| Yazi keymap | preserved exactly | Normalized keymap hashes match. |
+| Yazi settings | preserved modulo HM defaults | Normalized diff shows Dendritic adds only empty `opener`, `plugin`, and `which` sets; authored manager/input/preview behavior is otherwise equal. Keymap is exactly equal. |
+| Zoxide | preserved | Enabled in both; Dendritic shell integration is explicit. |
+| Codex | preserved, better placement | Enabled in both. Dendritic moves it from a host-local HM import into the development preset. |
+| Zen profile customization/manual opener | missing/changed | Main HM closure contains managed Zen/Firefox profile files and browser-specific manual behavior. Dendritic browser backend currently supplies default opener/app path but not profile management. High-level browser interface remains exploratory. |
 
-For each item classify preserved, accepted change, missing, irrelevant, or
-unverified and cite exact option/config evidence. Do not infer parity from a new
-file having the same tool name.
+The effective shell environment also reveals that Main's `xdg.enable=true`
+exports `XDG_BIN_HOME`, `XDG_CACHE_HOME`, `XDG_CONFIG_HOME`, `XDG_DATA_HOME`,
+and `XDG_STATE_HOME`, while Dendritic currently exports none of them. Dendritic
+adds `BROWSER`, `PAGER`, `LESS`, and BATDIFF through explicit capabilities.
+Both export editor and FZF/Starship values. Main additionally exports a TERMINFO
+path. Treat XDG and TERMINFO as concrete foundation/terminal parity work.
+
+Still complete Git/GH identity behavior, exact generated Bash/FZF integration
+scripts, terminal/Kitty behavior, and generated file/activation effects. Then
+classify every decision-required row with the owner before fixing or porting it.
+Do not turn old behavior into a requirement automatically.
 
 ## Known closure/evaluation concerns
 
@@ -606,6 +654,55 @@ Do not treat this likely sequence as approved implementation detail until the
 audit and dependency graph establish exact commits.
 
 ## Working protocol for future agents
+
+### Mandatory architectural decision synchronization
+
+Conversation is not the durable source of truth. Whenever the owner makes a
+decision that changes architectural direction, scope, priority, accepted
+behavior, terminology, a migration gate, or the status of an interface, the
+active agent must synchronize that decision into this playback bundle.
+
+This applies to explicit decisions and to corrections such as:
+
+- accepting or rejecting a parity difference;
+- declaring an interface settled, exploratory, superseded, or intentionally
+  omitted;
+- changing which lane lands first;
+- changing the relationship between bridge work and feature-branch work;
+- establishing a new invariant, exception, priority ordering, or closure rule;
+- correcting the old/new closure graph or branch mechanics;
+- answering an open question in a way that changes future implementation.
+
+Use this protocol immediately after the decision, before continuing work whose
+interpretation depends on it:
+
+1. restate the decision and its consequence to the owner, checking that the
+   interpretation is unambiguous;
+2. locate every affected statement, ledger row, acceptance gate, next step, and
+   route in `.agents/dendritic/context.md` and `routes.tsv`;
+3. update those locations consistently—do not merely append a contradictory
+   note while leaving stale instructions elsewhere;
+4. preserve relevant historical evidence and label the new status/decision;
+   distinguish a changed owner decision from a newly discovered fact;
+5. run `.agents/dendritic/context.sh refresh` to regenerate the manifest and
+   root `AGENTS.md` proxy hash;
+6. run `.agents/dendritic/context.sh verify`, route-expansion checks, shellcheck,
+   and `git diff --check`;
+7. inspect the canonical and generated diffs for accidental loss;
+8. commit the bundle update with the implementation that embodies the decision,
+   or make an immediate context-only commit when implementation will follow in
+   later work;
+9. report the commit and new proxy hash. Do not claim persistence before the
+   commit exists.
+
+If a later discovery contradicts a recorded decision, do not silently rewrite
+history or implement around it. Surface the contradiction, obtain direction if
+the resolution is not already implied, and then run this protocol again.
+
+The active long-running goal, conversation transcript, local caches, plans, and
+model memory are useful indexes but are not substitutes for this committed
+bundle. A future model must be able to reconstruct the current architecture and
+why it changed using repository state alone.
 
 At the start of every continuation:
 

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -129,6 +129,102 @@ Atomicity is semantic. A 150-line backend may be one correct capability. Ten
 five-line files are still a monolith if they always activate together or can
 only be consumed as a bundle.
 
+### Federated kConfig direction and native Nix substrate
+
+The broader architectural ambition is usefully described as reviving Linux
+`kConfig` as a federated module-system architecture over `pkgs`, implemented
+with Nix modules. Capabilities publish typed/mergeable declarations, multiple
+independent contributors extend them, and an owning interpreter lowers the
+completed namespace into package sets, modules, derivations, or platform
+configuration. Unlike a single global kernel configuration, the system is
+federated across nested module systems and package scopes; no central file must
+know every capability or implementation.
+
+This is a direction and evaluation model, not permission to invent one giant
+framework before the HM bridge lands. The owner has a successful work
+implementation as evidence that the model is viable, but this repository must
+discover and land its interfaces incrementally through real consumers.
+
+Preserve these substrate laws when extending the architecture:
+
+- Dendritic is a composition property, not a directory convention.
+- Prefer many contributors merging inert declarations followed by one owning
+  interpreter. Late interpretation gives the completed virtual namespace a
+  chance to reach a merge fixed point before lowering.
+- A framework may validate, normalize, or synthesize public data, but it must
+  not monopolize expression. A knowledgeable caller should be able to write an
+  equivalent public attrset/module declaration with ordinary Nix.
+- Higher abstractions must compose recognizable Nix machinery—module merging,
+  overlays, scopes, `callPackage`, fixed points, derivation extension, and
+  ordinary overrides—rather than hiding an incompatible parallel universe.
+- Merge semantics are a primary API. Test two independent contributors,
+  removal of an integration, replacement of a backend, and adversarial
+  transformation order, not only a single happy-path configuration.
+- Keep flake-level, NixOS/nix-darwin, Home Manager, and package-local module
+  systems conceptually distinct. Similar module arguments do not make their
+  fixed points, applicability, or ownership interchangeable.
+- Choose outer versus inner `lib` and package scopes as part of the contract.
+  Scope-sensitive dependencies must resolve through the intended derived
+  package set; do not accidentally capture a convenient outer `pkgs`.
+- Reason about recursive package/module fixed points structurally. `final` and
+  `prev` are semantic positions, not imperative time steps, and nested fixed
+  points may behave like coupled gears rather than an inner computation that
+  wholly finishes before an outer one begins.
+- Preserve ordinary Nix as an escape hatch and keep public APIs semantic. Do
+  not expose arbitrary fixed-point seeds, mirrored `finalAttrs`, or framework
+  internals as the lasting contract.
+
+Two longer-horizon research lanes came from the online architectural history.
+They are durable context but are not prerequisites for the current HM bridge:
+
+1. Hierarchical cross-package scopes must combine accumulated package-set
+   transformations with child subscopes. The motivating form was an MSP430
+   scope containing libc/runtime environments, MCU families, and concrete
+   members. Plain nested attrsets solve only half the problem; descendants must
+   inherit the relevant overlay/scope transformations, and the resulting
+   public representation must remain hand-writable. The final schema,
+   splicing, sysroot, toolchain, and node boundaries remain unresolved here.
+2. Module-configurable packages may expose a semantic operation such as
+   `pkg.withConfig moduleDelta`, returning another configurable package. The
+   non-negotiable adversarial law, if this API family is used, is
+   `withConfig A -> overrideAttrs B -> withConfig C`: `C` must forward-rebase
+   from the package currently in hand so `B` survives. Static variants are not
+   a substitute for dynamic rebasing. Historical `finalPackage` machinery is
+   evidence of the stale-base bug, not an implementation prescription.
+
+The same empirical method applies to future boot/provisioning design: derive
+interfaces from materially different proof cases (EFI, supported BIOS/non-EFI,
+encrypted/provisioned storage) instead of generalizing one working host. These
+lanes are provenance-preserved research, not current landing scope.
+
+### Supplemental online-context reconciliation (2026-08-12)
+
+The owner supplied an online architectural synthesis and proxy bundle as
+historical context. Source fingerprints at import time were:
+
+- `AGENTS.md — nix-systems Architectural Intent.md`:
+  `7c1b276e04103f0a88df95590355f7b2173ef8b933bceae8d32e12aef6d83060`
+- `dendritic-online-context.tar.gz`:
+  `82ff3a71627437710830450fcc45553c49be158364e485d958e1dd6fd6c3cfb2`
+
+The source files lived in the owner's Downloads directory and are not required
+for replay. The accepted, non-duplicative semantics are normalized above so
+this committed bundle remains self-producing. Provenance is
+`candidate online history, reconciled by local Codex on 2026-08-12`; current
+committed local context and later owner decisions remain authoritative.
+
+Do not resurrect the online bundle's stale uncertainties. Local context has
+already settled the input/follows priority, vTable framing, profiles as
+presets, trunk bridge, HM-first lane, sysroot/input registry, closure taxonomy,
+and current removals. Its tentative Helix-under-interactive-shell placement is
+not accepted; editor remains a separately reasoned capability. Its browser,
+fonts, desktop, applications, identity, secrets, and remote-builder gaps convey
+no design recommendation beyond the explicit local decisions in this file.
+
+The import added no reason to reopen the current HM closure choices. It adds
+composition laws and distant research lanes; it does not enlarge the first
+bridge slice.
+
 ### Profiles
 
 Profiles are intentionally opinionated presets. They compose through imports

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -347,6 +347,16 @@ Always re-check these facts. They are historical coordinates, not permanent
 truth. Use `git status --short --branch`, `git branch -vv`, `git worktree list`,
 and `git merge-base main dendritic` before acting.
 
+Keep migration and controlled predecessor-thaw work in dedicated temporary
+worktrees rather than moving it into the owner's primary
+`/Users/krad246/.config/dotfiles` worktree. The temporary names may be awkward,
+but their isolation protects the primary checkout and makes branch ownership
+explicit throughout the bridge effort. If the owner later proposes removing
+them early, remind them of this recorded decision and recommend retaining the
+isolation; the owner may explicitly override it. Perform the final primary-
+worktree changeover only after the predecessor repository/bridge machinery has
+been completely eliminated and the migration is ready to replace it.
+
 The branches also differ in dependency era. Current `main` uses 26.05 inputs,
 while frozen `dendritic` uses 25.11 for Nixpkgs, Home Manager, and nix-darwin.
 Never treat lockfiles or generated `flake.nix` as mechanically interchangeable.
@@ -908,6 +918,14 @@ agent reports evidence, remaining questions, and next selectable lanes
           ↺
 ```
 
+The owner permits bounded asynchronous sub-agent work for mechanical context
+checkpointing and propagation, cache-mirror verification, periodic recovery
+maintenance, and similarly isolated validation tasks. The primary agent retains
+architectural judgment, conflict resolution, and ownership of the active
+implementation lane. Before delegating shared-worktree mutations, assign
+non-overlapping files or make the sub-agent read-only; never allow concurrent
+agents to race on the canonical bundle or generated projections.
+
 ### Reasoning about invariants
 
 Before designing or changing a capability, extract its invariants in plain
@@ -1074,6 +1092,12 @@ public command generic: today it delegates to the Dendritic bundle's
 `checkpoint` primitive, but future agent-maintained internal documentation may
 replace or extend that storage without renaming the lifecycle action. A matching
 Just command namespace is a possible convenience layer, not current scope.
+
+Checkpoint/propagation work may run in a bounded sub-agent while the primary
+agent continues an independent implementation lane. Treat the canonical bundle
+as single-writer state: delegate either the complete checkpoint operation or
+read-only verification, and do not concurrently edit its inputs or generated
+outputs from another agent.
 
 ### Mandatory architectural decision synchronization
 

--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -327,6 +327,33 @@ composition, and consumption semantics. Retain or rebuild useful outputs behind
 the redesigned Dendritic module/policy structure. Never use schema shrinkage as
 a proxy for architectural quality.
 
+Treat `nixConfig` as repository execution policy, not host daemon policy. It
+should make evaluating and building this flake reliable and efficient across
+heterogeneous development machines by declaring required features, public and
+private caches/keys, substitution/fallback behavior, portable autoscaling
+defaults such as `cores = 0` and `max-jobs = auto`, and bounded connection plus
+long-running build/silence timeouts. Keep trusted users, build users, sandbox
+policy, store retention/free-space policy, remote-builder topology, and other
+machine facts in system capabilities. Ambient/user CLI configuration may
+override the repository preset.
+
+Use flake-parts partitions to separate expensive or specialized output lanes
+when their real input/evaluation cones justify it. The partition module is
+already imported on the main-based branch; turn that substrate into meaningful
+boundaries rather than cosmetic partitioning. A partition should reduce the
+inputs and modules forced by ordinary evaluation while preserving the rich
+output surface and an obvious consumer path.
+
+Terraform the main-based `flake.lock` incrementally toward Dendritic's disciplined
+graph as capability lanes land. For each coherent port, identify which inputs
+still have consumers, remove obsolete declarations only after those consumers
+move, apply explicit `follows`/deduplication, and prune nodes that become
+unreachable. Do not copy Dendritic's older lockfile wholesale or optimize for a
+node-count target. Every lock change must be attributable to a source consumer,
+partition boundary, or follows relationship and verified through the affected
+outputs. Large portions of the graph should disappear naturally as legacy
+frameworks and output lanes become worthless to the successor architecture.
+
 For the initial HM base port, retain `check-flake` and `check-flake-file`
 unchanged. A separate temporary `realize-dendritic-hm-base` pre-push hook may
 refer symbolically to `config.checks.dendritic-hm-base.drvPath`, discard its
@@ -1119,6 +1146,14 @@ setup is broken. Nix apps and Just recipes are typed/convenient front doors over
 that primitive, not its only execution path. Ambient environment is an override
 and recovery seam only for tools that deliberately support it, not a substitute
 for statically declaring ordinary tool dependencies or local target discovery.
+
+Treat an exported environment variable as publication onto a process-tree
+software bus: downstream programs consume it implicitly. Publish uppercase or
+exported state only when that bus is an intentional, documented contract with
+real consumers. Otherwise keep implementation state in lowercase shell-local
+variables. Prefer explicit arguments, structural location, or typed inputs over
+reading ambient bus values; stale environment inherited from another devshell
+or worktree must not redirect bootstrap or mutation targets.
 
 Checkpoint/propagation work may run in a bounded sub-agent while the primary
 agent continues an independent implementation lane. Treat the canonical bundle

--- a/.agents/dendritic/context.sh
+++ b/.agents/dendritic/context.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+bundle="$root/.agents/dendritic"
+context="$bundle/context.md"
+routes="$bundle/routes.tsv"
+manifest="$bundle/manifest"
+bootstrap="$root/AGENTS.md"
+
+digest() {
+  (
+    cd "$root"
+    shasum -a 256 .agents/dendritic/context.md .agents/dendritic/routes.tsv
+  ) | shasum -a 256 | awk '{print $1}'
+}
+
+section() {
+  local heading="$1"
+  awk -v wanted="$heading" '
+    function level(line, copy) {
+      copy = line
+      sub(/[^#].*$/, "", copy)
+      return length(copy)
+    }
+    /^#+ / {
+      current = substr($0, level($0) + 2)
+      if (printing && level($0) <= start_level) exit
+      if (current == wanted) {
+        printing = 1
+        start_level = level($0)
+      }
+    }
+    printing
+  ' "$context"
+}
+
+lookup() {
+  local key="$1"
+  awk -F '\t' -v wanted="$key" '$1 == wanted {print $2; found=1} END {exit !found}' "$routes"
+}
+
+verify() {
+  local actual expected
+  actual="$(digest)"
+  expected="$(awk -F= '$1 == "proxy-sha256" {print $2}' "$manifest")"
+  if [[ -z "$expected" || "$actual" != "$expected" ]]; then
+    printf 'STALE context bundle\nexpected: %s\nactual:   %s\nrun: %s refresh\n' \
+      "${expected:-missing}" "$actual" "$0" >&2
+    return 1
+  fi
+  printf '%s\n' "$actual"
+}
+
+refresh() {
+  local hash tmp_manifest tmp_bootstrap
+  hash="$(digest)"
+  tmp_manifest="$(mktemp "${TMPDIR:-/tmp}/dendritic-manifest.XXXXXX")"
+  tmp_bootstrap="$(mktemp "${TMPDIR:-/tmp}/dendritic-agents.XXXXXX")"
+  trap 'rm -f "$tmp_manifest" "$tmp_bootstrap"' EXIT
+
+  {
+    printf 'format=dendritic-context-v1\n'
+    printf 'proxy-sha256=%s\n' "$hash"
+    printf 'canonical=.agents/dendritic/context.md\n'
+    printf 'routes=.agents/dendritic/routes.tsv\n'
+    printf 'generator=.agents/dendritic/context.sh\n'
+  } >"$tmp_manifest"
+
+  sed "s/@PROXY_SHA256@/$hash/g" "$bundle/AGENTS.template.md" >"$tmp_bootstrap"
+  mv "$tmp_manifest" "$manifest"
+  mv "$tmp_bootstrap" "$bootstrap"
+  trap - EXIT
+  printf 'refreshed %s\n' "$hash"
+}
+
+case "${1:-help}" in
+  verify)
+    verify
+    ;;
+  hash)
+    digest
+    ;;
+  list)
+    verify >/dev/null
+    awk -F '\t' '!/^#/ {printf "%-16s %s\n", $1, $3}' "$routes"
+    ;;
+  read)
+    verify >/dev/null
+    [[ $# -ge 2 ]] || { printf 'usage: %s read ROUTE...\n' "$0" >&2; exit 2; }
+    shift
+    for key in "$@"; do
+      heading="$(lookup "$key")" || { printf 'unknown route: %s\n' "$key" >&2; exit 2; }
+      section "$heading"
+    done
+    ;;
+  full)
+    verify >/dev/null
+    cat "$context"
+    ;;
+  refresh)
+    refresh
+    ;;
+  help|*)
+    cat <<EOF
+Usage: $0 COMMAND
+
+  verify          fail if canonical context/routes differ from the proxy hash
+  hash            print the current canonical content hash
+  list            list lazy context routes
+  read ROUTE...   expand selected canonical sections
+  full            expand the complete canonical context
+  refresh         regenerate manifest and root AGENTS.md after canonical edits
+
+For architecture changes, migration planning, or uncertainty, use 'full'.
+EOF
+    ;;
+esac

--- a/.agents/dendritic/context.sh
+++ b/.agents/dendritic/context.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 command="${1:-help}"
-root="${2:-$(git rev-parse --show-toplevel)}"
-bundle="${3:-$root/.agents/dendritic}"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+root="${2:-$(cd "$script_dir/../.." && pwd)}"
+bundle="${3:-$script_dir}"
 context="$bundle/context.md"
 routes="$bundle/routes.tsv"
 manifest="$bundle/manifest"

--- a/.agents/dendritic/context.sh
+++ b/.agents/dendritic/context.sh
@@ -1,10 +1,38 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-command="${1:-help}"
 script_dir="$(cd "$(dirname "$0")" && pwd)"
-root="${2:-$(cd "$script_dir/../.." && pwd)}"
-bundle="${3:-$script_dir}"
+root="$(cd "$script_dir/../.." && pwd)"
+bundle="$script_dir"
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--root)
+		[[ $# -ge 2 ]] || {
+			printf '%s\n' 'context: --root requires a path' >&2
+			exit 2
+		}
+		root="$2"
+		shift 2
+		;;
+	--bundle)
+		[[ $# -ge 2 ]] || {
+			printf '%s\n' 'context: --bundle requires a path' >&2
+			exit 2
+		}
+		bundle="$2"
+		shift 2
+		;;
+	--)
+		shift
+		break
+		;;
+	*) break ;;
+	esac
+done
+
+command="${1:-help}"
+[[ $# -eq 0 ]] || shift
 context="$bundle/context.md"
 routes="$bundle/routes.tsv"
 manifest="$bundle/manifest"
@@ -157,11 +185,10 @@ list)
 	;;
 read)
 	verify >/dev/null
-	[[ $# -ge 2 ]] || {
+	[[ $# -ge 1 ]] || {
 		printf 'usage: %s read ROUTE...\n' "$0" >&2
 		exit 2
 	}
-	shift
 	for key in "$@"; do
 		heading="$(lookup "$key")" || {
 			printf 'unknown route: %s\n' "$key" >&2
@@ -190,7 +217,7 @@ refresh)
 	;;
 help | *)
 	cat <<EOF
-Usage: $0 COMMAND
+Usage: $0 [--root ROOT] [--bundle BUNDLE] COMMAND [ARGS...]
 
   verify          fail if canonical context/routes differ from the proxy hash
   hash            print the current canonical content hash

--- a/.agents/dendritic/context.sh
+++ b/.agents/dendritic/context.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-root="$(git rev-parse --show-toplevel)"
-bundle="$root/.agents/dendritic"
+command="${1:-help}"
+root="${2:-$(git rev-parse --show-toplevel)}"
+bundle="${3:-$root/.agents/dendritic}"
 context="$bundle/context.md"
 routes="$bundle/routes.tsv"
 manifest="$bundle/manifest"
@@ -11,10 +12,21 @@ cache_dir="${CODEX_CONFIG_DIR:-$HOME/.config/codex}/cache/project-charters"
 cache_context="$cache_dir/dotfiles-dendritic-grand-vision.md"
 cache_ledger="$cache_dir/dotfiles-nixbook-pro-closure-ledger.md"
 
+validate_paths() {
+	[[ -d $root && -f $root/flake.nix ]] || {
+		printf 'invalid flake root: %s\n' "$root" >&2
+		return 1
+	}
+	[[ -f $context && -f $routes && -f $bundle/AGENTS.template.md ]] || {
+		printf 'invalid context bundle: %s\n' "$bundle" >&2
+		return 1
+	}
+}
+
 digest() {
 	(
-		cd "$root"
-		shasum -a 256 .agents/dendritic/context.md .agents/dendritic/routes.tsv
+		cd "$bundle"
+		shasum -a 256 context.md routes.tsv
 	) | shasum -a 256 | awk '{print $1}'
 }
 
@@ -124,7 +136,14 @@ refresh() {
 	printf 'refreshed %s\n' "$hash"
 }
 
-case "${1:-help}" in
+checkpoint() {
+	validate_paths
+	refresh
+	verify
+	verify_cache
+}
+
+case "$command" in
 verify)
 	verify
 	;;
@@ -162,6 +181,9 @@ verify-cache)
 	verify >/dev/null
 	verify_cache
 	;;
+checkpoint)
+	checkpoint
+	;;
 refresh)
 	refresh
 	;;
@@ -177,6 +199,7 @@ Usage: $0 COMMAND
   refresh         regenerate proxy files and local cache mirrors after edits
   sync-cache      replace local cache mirrors from verified canonical context
   verify-cache    fail if local cache mirrors differ from canonical context
+  checkpoint      refresh and verify canonical context and local mirrors
 
 For architecture changes, migration planning, or uncertainty, use 'full'.
 EOF

--- a/.agents/dendritic/context.sh
+++ b/.agents/dendritic/context.sh
@@ -7,17 +7,20 @@ context="$bundle/context.md"
 routes="$bundle/routes.tsv"
 manifest="$bundle/manifest"
 bootstrap="$root/AGENTS.md"
+cache_dir="${CODEX_CONFIG_DIR:-$HOME/.config/codex}/cache/project-charters"
+cache_context="$cache_dir/dotfiles-dendritic-grand-vision.md"
+cache_ledger="$cache_dir/dotfiles-nixbook-pro-closure-ledger.md"
 
 digest() {
-  (
-    cd "$root"
-    shasum -a 256 .agents/dendritic/context.md .agents/dendritic/routes.tsv
-  ) | shasum -a 256 | awk '{print $1}'
+	(
+		cd "$root"
+		shasum -a 256 .agents/dendritic/context.md .agents/dendritic/routes.tsv
+	) | shasum -a 256 | awk '{print $1}'
 }
 
 section() {
-  local heading="$1"
-  awk -v wanted="$heading" '
+	local heading="$1"
+	awk -v wanted="$heading" '
     function level(line, copy) {
       copy = line
       sub(/[^#].*$/, "", copy)
@@ -36,73 +39,134 @@ section() {
 }
 
 lookup() {
-  local key="$1"
-  awk -F '\t' -v wanted="$key" '$1 == wanted {print $2; found=1} END {exit !found}' "$routes"
+	local key="$1"
+	awk -F '\t' -v wanted="$key" '$1 == wanted {print $2; found=1} END {exit !found}' "$routes"
 }
 
 verify() {
-  local actual expected
-  actual="$(digest)"
-  expected="$(awk -F= '$1 == "proxy-sha256" {print $2}' "$manifest")"
-  if [[ -z "$expected" || "$actual" != "$expected" ]]; then
-    printf 'STALE context bundle\nexpected: %s\nactual:   %s\nrun: %s refresh\n' \
-      "${expected:-missing}" "$actual" "$0" >&2
-    return 1
-  fi
-  printf '%s\n' "$actual"
+	local actual expected
+	actual="$(digest)"
+	expected="$(awk -F= '$1 == "proxy-sha256" {print $2}' "$manifest")"
+	if [[ -z $expected || $actual != "$expected" ]]; then
+		printf 'STALE context bundle\nexpected: %s\nactual:   %s\nrun: %s refresh\n' \
+			"${expected:-missing}" "$actual" "$0" >&2
+		return 1
+	fi
+	printf '%s\n' "$actual"
+}
+
+sync_cache() {
+	mkdir -p "$cache_dir"
+	cp "$context" "$cache_context"
+	render_ledger >"$cache_ledger"
+}
+
+render_ledger() {
+	local source_note gates
+	# These are literal Markdown code spans, not attempted shell expansion.
+	# shellcheck disable=SC2016
+	source_note='Generated from `.agents/dendritic/context.md`; edit the repository context, not this mirror.'
+	# shellcheck disable=SC2016
+	gates='Acceptance gates for the `nixbook-pro` slice'
+	{
+		printf '# nixbook-pro closure ledger\n\n'
+		printf '%s\n\n' "$source_note"
+		section 'Explicit owner decisions: do not reopen without new direction'
+		printf '\n'
+		section 'Behavioral parity ledger (evidence as of this handoff)'
+		printf '\n'
+		section "$gates"
+		printf '\n'
+		section 'Immediate next work'
+	}
+}
+
+verify_cache() {
+	local tmp_ledger
+	cmp -s "$context" "$cache_context" || {
+		printf 'STALE local context mirror: %s\nrun: %s sync-cache\n' \
+			"$cache_context" "$0" >&2
+		return 1
+	}
+	tmp_ledger="$(mktemp "${TMPDIR:-/tmp}/dendritic-ledger.XXXXXX")"
+	trap 'rm -f "$tmp_ledger"' EXIT
+	render_ledger >"$tmp_ledger"
+	cmp -s "$tmp_ledger" "$cache_ledger" || {
+		printf 'STALE local closure-ledger mirror: %s\nrun: %s sync-cache\n' \
+			"$cache_ledger" "$0" >&2
+		return 1
+	}
+	trap - EXIT
+	rm -f "$tmp_ledger"
+	printf 'local cache mirrors match canonical context\n'
 }
 
 refresh() {
-  local hash tmp_manifest tmp_bootstrap
-  hash="$(digest)"
-  tmp_manifest="$(mktemp "${TMPDIR:-/tmp}/dendritic-manifest.XXXXXX")"
-  tmp_bootstrap="$(mktemp "${TMPDIR:-/tmp}/dendritic-agents.XXXXXX")"
-  trap 'rm -f "$tmp_manifest" "$tmp_bootstrap"' EXIT
+	local hash tmp_manifest tmp_bootstrap
+	hash="$(digest)"
+	tmp_manifest="$(mktemp "${TMPDIR:-/tmp}/dendritic-manifest.XXXXXX")"
+	tmp_bootstrap="$(mktemp "${TMPDIR:-/tmp}/dendritic-agents.XXXXXX")"
+	trap 'rm -f "$tmp_manifest" "$tmp_bootstrap"' EXIT
 
-  {
-    printf 'format=dendritic-context-v1\n'
-    printf 'proxy-sha256=%s\n' "$hash"
-    printf 'canonical=.agents/dendritic/context.md\n'
-    printf 'routes=.agents/dendritic/routes.tsv\n'
-    printf 'generator=.agents/dendritic/context.sh\n'
-  } >"$tmp_manifest"
+	{
+		printf 'format=dendritic-context-v1\n'
+		printf 'proxy-sha256=%s\n' "$hash"
+		printf 'canonical=.agents/dendritic/context.md\n'
+		printf 'routes=.agents/dendritic/routes.tsv\n'
+		printf 'generator=.agents/dendritic/context.sh\n'
+	} >"$tmp_manifest"
 
-  sed "s/@PROXY_SHA256@/$hash/g" "$bundle/AGENTS.template.md" >"$tmp_bootstrap"
-  mv "$tmp_manifest" "$manifest"
-  mv "$tmp_bootstrap" "$bootstrap"
-  trap - EXIT
-  printf 'refreshed %s\n' "$hash"
+	sed "s/@PROXY_SHA256@/$hash/g" "$bundle/AGENTS.template.md" >"$tmp_bootstrap"
+	mv "$tmp_manifest" "$manifest"
+	mv "$tmp_bootstrap" "$bootstrap"
+	trap - EXIT
+	sync_cache
+	printf 'refreshed %s\n' "$hash"
 }
 
 case "${1:-help}" in
-  verify)
-    verify
-    ;;
-  hash)
-    digest
-    ;;
-  list)
-    verify >/dev/null
-    awk -F '\t' '!/^#/ {printf "%-16s %s\n", $1, $3}' "$routes"
-    ;;
-  read)
-    verify >/dev/null
-    [[ $# -ge 2 ]] || { printf 'usage: %s read ROUTE...\n' "$0" >&2; exit 2; }
-    shift
-    for key in "$@"; do
-      heading="$(lookup "$key")" || { printf 'unknown route: %s\n' "$key" >&2; exit 2; }
-      section "$heading"
-    done
-    ;;
-  full)
-    verify >/dev/null
-    cat "$context"
-    ;;
-  refresh)
-    refresh
-    ;;
-  help|*)
-    cat <<EOF
+verify)
+	verify
+	;;
+hash)
+	digest
+	;;
+list)
+	verify >/dev/null
+	awk -F '\t' '!/^#/ {printf "%-16s %s\n", $1, $3}' "$routes"
+	;;
+read)
+	verify >/dev/null
+	[[ $# -ge 2 ]] || {
+		printf 'usage: %s read ROUTE...\n' "$0" >&2
+		exit 2
+	}
+	shift
+	for key in "$@"; do
+		heading="$(lookup "$key")" || {
+			printf 'unknown route: %s\n' "$key" >&2
+			exit 2
+		}
+		section "$heading"
+	done
+	;;
+full)
+	verify >/dev/null
+	cat "$context"
+	;;
+sync-cache)
+	verify >/dev/null
+	sync_cache
+	;;
+verify-cache)
+	verify >/dev/null
+	verify_cache
+	;;
+refresh)
+	refresh
+	;;
+help | *)
+	cat <<EOF
 Usage: $0 COMMAND
 
   verify          fail if canonical context/routes differ from the proxy hash
@@ -110,9 +174,11 @@ Usage: $0 COMMAND
   list            list lazy context routes
   read ROUTE...   expand selected canonical sections
   full            expand the complete canonical context
-  refresh         regenerate manifest and root AGENTS.md after canonical edits
+  refresh         regenerate proxy files and local cache mirrors after edits
+  sync-cache      replace local cache mirrors from verified canonical context
+  verify-cache    fail if local cache mirrors differ from canonical context
 
 For architecture changes, migration planning, or uncertainty, use 'full'.
 EOF
-    ;;
+	;;
 esac

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=bf219374e8ae33a9043c4b595ab59c304075e10e9e46197526b0c568a430669f
+proxy-sha256=85bef7edc0a846bf4526898267c45db9925ffca8dfdc5c42f7e2c9517693d456
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=b9bc27a4ffecc6c690c794926a7f69d768b14c66c6bdb02ee7aa69896d79f951
+proxy-sha256=398b17f08cd459d3c96e24dc11f8ab9b411f879c750c84445dd13ab4fb8a6eda
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=694f15d791feda17f71bb3d42e6a80b6d8e8bc71aa2b3605ec3708cb57e76655
+proxy-sha256=52f16c40175b22360763fc3b2bb2f673ce144e67f70453cce194352828370c6a
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=df99908f701340c9a8c2587de53429e470049c109bfeddc8e012a9001c13d0c1
+proxy-sha256=2c456a9f2451df954f2440fb482d3e1b5c780a8ba209ad053f38017a000b751a
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=2c456a9f2451df954f2440fb482d3e1b5c780a8ba209ad053f38017a000b751a
+proxy-sha256=37bcdaaead0217941da55193f5748ffd421b521cadd0cabf673a86cbeb4fe898
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=52f16c40175b22360763fc3b2bb2f673ce144e67f70453cce194352828370c6a
+proxy-sha256=281c4396d9d1aa3f21dbe9fe67f68c01c12aaedd574bf4ed99e8cac2f2287f78
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=8194b06fceb7054562a24080baddaa0fa15834c775b2202a1a5521a9a81796cc
+proxy-sha256=f9550df00d89e8ae8ec6df8cfa6798aa5f3ffe1f5c214e18f8147f0097820c19
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=398b17f08cd459d3c96e24dc11f8ab9b411f879c750c84445dd13ab4fb8a6eda
+proxy-sha256=8194b06fceb7054562a24080baddaa0fa15834c775b2202a1a5521a9a81796cc
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=1861fd3716c130c89b28ae755af620a2b5845f00ecb642ca3a3154ed68d4a166
+proxy-sha256=df99908f701340c9a8c2587de53429e470049c109bfeddc8e012a9001c13d0c1
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=85bef7edc0a846bf4526898267c45db9925ffca8dfdc5c42f7e2c9517693d456
+proxy-sha256=47a59104aaf785777da997888bff79c0c7c94dbebaba31582d50d25474e3e416
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=f9550df00d89e8ae8ec6df8cfa6798aa5f3ffe1f5c214e18f8147f0097820c19
+proxy-sha256=1861fd3716c130c89b28ae755af620a2b5845f00ecb642ca3a3154ed68d4a166
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=37bcdaaead0217941da55193f5748ffd421b521cadd0cabf673a86cbeb4fe898
+proxy-sha256=694f15d791feda17f71bb3d42e6a80b6d8e8bc71aa2b3605ec3708cb57e76655
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,0 +1,5 @@
+format=dendritic-context-v1
+proxy-sha256=b3f950070e885d0531fa6b9b6c7b87e3aa88b5eabcdc41b3a931d426aa73520b
+canonical=.agents/dendritic/context.md
+routes=.agents/dendritic/routes.tsv
+generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=2cbc88532ec5f55ac69085ba1d0ba1052676e966a423eed431fd805623b347c4
+proxy-sha256=b10a7cb4762d69e4a1ced414ed4367de1f3517f0c162e98e3afaf076aa6f9aae
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=5601142cf07845736fedf4beaafdf64abe350f02475df7cf324da7fb7dd582ab
+proxy-sha256=f2226cfd8f64f57e18c90561ab17db2ae93fb418b7049c8d0606c802bd3fcba3
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=b3f950070e885d0531fa6b9b6c7b87e3aa88b5eabcdc41b3a931d426aa73520b
+proxy-sha256=2cbc88532ec5f55ac69085ba1d0ba1052676e966a423eed431fd805623b347c4
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=47a59104aaf785777da997888bff79c0c7c94dbebaba31582d50d25474e3e416
+proxy-sha256=b9bc27a4ffecc6c690c794926a7f69d768b14c66c6bdb02ee7aa69896d79f951
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=b10a7cb4762d69e4a1ced414ed4367de1f3517f0c162e98e3afaf076aa6f9aae
+proxy-sha256=5601142cf07845736fedf4beaafdf64abe350f02475df7cf324da7fb7dd582ab
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=f2226cfd8f64f57e18c90561ab17db2ae93fb418b7049c8d0606c802bd3fcba3
+proxy-sha256=bf219374e8ae33a9043c4b595ab59c304075e10e9e46197526b0c568a430669f
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/.agents/dendritic/routes.tsv
+++ b/.agents/dendritic/routes.tsv
@@ -1,6 +1,8 @@
 # key	heading	purpose
 mission	Mission and stopping condition	Objective, sequence, and two-consumer HM thesis
 architecture	Authoritative architectural intent	Capability vTables, backends, integrations, profiles, and closure priorities
+federation	Federated kConfig direction and native Nix substrate	Federated module-system goal, native Nix laws, fixed points, cross scopes, and forward rebasing
+online-import	Supplemental online-context reconciliation (2026-08-12)	Provenance, accepted additions, and superseded online uncertainties
 hm	First polished landing: low-level Home Manager	HM landing requirements
 flake	`ezConfigs` and flake composition	Flake substrate, input discipline, and ezConfigs disposition
 topology	Branch topology and migration hazard	Branch/worktree/input-version hazards

--- a/.agents/dendritic/routes.tsv
+++ b/.agents/dendritic/routes.tsv
@@ -13,6 +13,9 @@ parity	Behavioral parity ledger (evidence as of this handoff)	Darwin, applicatio
 closures	Known closure/evaluation concerns	Source/eval/derivation distinctions and accepted dispatch tax
 gates	Acceptance gates for the `nixbook-pro` slice	Non-negotiable verification gates
 bridge	Bridge-to-main constraints	Coexistence constraints and likely landing order
+collaboration	Contractor relationship and questioning style	Boss-agent responsibilities and evidence-backed question protocol
+invariants	Reasoning about invariants	How to define, test, refine, and persist invariants
+rootfs	Evolving the context root filesystem	How to extend the executable context bundle as feedback evolves
 decision-sync	Mandatory architectural decision synchronization	Required protocol for persisting owner pivots and corrections
 protocol	Working protocol for future agents	How to resume, analyze, edit, verify, and commit
 next	Immediate next work	Ordered continuation queue

--- a/.agents/dendritic/routes.tsv
+++ b/.agents/dendritic/routes.tsv
@@ -15,6 +15,7 @@ gates	Acceptance gates for the `nixbook-pro` slice	Non-negotiable verification g
 bridge	Bridge-to-main constraints	Coexistence constraints and likely landing order
 collaboration	Contractor relationship and questioning style	Boss-agent responsibilities and evidence-backed question protocol
 invariants	Reasoning about invariants	How to define, test, refine, and persist invariants
+proof-budget	Proof-carrying architecture and validation budget	When established invariants replace repeated downstream validation
 rootfs	Evolving the context root filesystem	How to extend the executable context bundle as feedback evolves
 decision-sync	Mandatory architectural decision synchronization	Required protocol for persisting owner pivots and corrections
 protocol	Working protocol for future agents	How to resume, analyze, edit, verify, and commit

--- a/.agents/dendritic/routes.tsv
+++ b/.agents/dendritic/routes.tsv
@@ -13,5 +13,6 @@ parity	Behavioral parity ledger (evidence as of this handoff)	Darwin, applicatio
 closures	Known closure/evaluation concerns	Source/eval/derivation distinctions and accepted dispatch tax
 gates	Acceptance gates for the `nixbook-pro` slice	Non-negotiable verification gates
 bridge	Bridge-to-main constraints	Coexistence constraints and likely landing order
+decision-sync	Mandatory architectural decision synchronization	Required protocol for persisting owner pivots and corrections
 protocol	Working protocol for future agents	How to resume, analyze, edit, verify, and commit
 next	Immediate next work	Ordered continuation queue

--- a/.agents/dendritic/routes.tsv
+++ b/.agents/dendritic/routes.tsv
@@ -4,7 +4,7 @@ architecture	Authoritative architectural intent	Capability vTables, backends, in
 federation	Federated kConfig direction and native Nix substrate	Federated module-system goal, native Nix laws, fixed points, cross scopes, and forward rebasing
 online-import	Supplemental online-context reconciliation (2026-08-12)	Provenance, accepted additions, and superseded online uncertainties
 hm	First polished landing: low-level Home Manager	HM landing requirements
-flake	`ezConfigs` and flake composition	Flake substrate, input discipline, and ezConfigs disposition
+flake	`ezConfigs` and flake composition	Flake substrate, rich output policy, input discipline, and ezConfigs disposition
 topology	Branch topology and migration hazard	Branch/worktree/input-version hazards
 legacy-closure	Correct definition of the old `nixbook-pro` logical closure	Hidden ezConfigs HM injection and old roots
 new-closure	Current Dendritic `nixbook-pro` root and composition	New root and transitive composition
@@ -14,11 +14,11 @@ unfinished	Explicitly unfinished or exploratory areas	Interfaces that must not b
 parity	Behavioral parity ledger (evidence as of this handoff)	Darwin, applications, and required HM parity work
 closures	Known closure/evaluation concerns	Source/eval/derivation distinctions and accepted dispatch tax
 gates	Acceptance gates for the `nixbook-pro` slice	Non-negotiable verification gates
-bridge	Bridge-to-main constraints	Coexistence constraints and likely landing order
+bridge	Bridge-to-main constraints	Landed predecessor bridge, coexistence constraints, and continuation order
 collaboration	Contractor relationship and questioning style	Boss-agent responsibilities and evidence-backed question protocol
 invariants	Reasoning about invariants	How to define, test, refine, and persist invariants
 proof-budget	Proof-carrying architecture and validation budget	When established invariants replace repeated downstream validation
-rootfs	Evolving the context root filesystem	How to extend the executable context bundle as feedback evolves
+rootfs	Evolving the context root filesystem	Write-through cache, cross-machine replay, and rootfs evolution
 decision-sync	Mandatory architectural decision synchronization	Required protocol for persisting owner pivots and corrections
 protocol	Working protocol for future agents	How to resume, analyze, edit, verify, and commit
 next	Immediate next work	Ordered continuation queue

--- a/.agents/dendritic/routes.tsv
+++ b/.agents/dendritic/routes.tsv
@@ -1,0 +1,17 @@
+# key	heading	purpose
+mission	Mission and stopping condition	Objective, sequence, and two-consumer HM thesis
+architecture	Authoritative architectural intent	Capability vTables, backends, integrations, profiles, and closure priorities
+hm	First polished landing: low-level Home Manager	HM landing requirements
+flake	`ezConfigs` and flake composition	Flake substrate, input discipline, and ezConfigs disposition
+topology	Branch topology and migration hazard	Branch/worktree/input-version hazards
+legacy-closure	Correct definition of the old `nixbook-pro` logical closure	Hidden ezConfigs HM injection and old roots
+new-closure	Current Dendritic `nixbook-pro` root and composition	New root and transitive composition
+patterns	Strongest architectural results so far	Reference shell/picker and remote-builder designs
+decisions	Explicit owner decisions: do not reopen without new direction	Accepted additions, removals, and narrowing
+unfinished	Explicitly unfinished or exploratory areas	Interfaces that must not be treated as settled
+parity	Behavioral parity ledger (evidence as of this handoff)	Darwin, applications, and required HM parity work
+closures	Known closure/evaluation concerns	Source/eval/derivation distinctions and accepted dispatch tax
+gates	Acceptance gates for the `nixbook-pro` slice	Non-negotiable verification gates
+bridge	Bridge-to-main constraints	Coexistence constraints and likely landing order
+protocol	Working protocol for future agents	How to resume, analyze, edit, verify, and commit
+next	Immediate next work	Ordered continuation queue

--- a/.envrc
+++ b/.envrc
@@ -9,15 +9,15 @@ export TMPDIR
 watch_dir ./flakeModules
 
 if type nix_direnv_manual_reload >/dev/null; then
-  nix_direnv_manual_reload
+	nix_direnv_manual_reload
 fi
 
 devShell=".#interactive"
 use flake "$devShell" \
-  --option experimental-features 'nix-command flakes' \
-  --option accept-flake-config true \
-  --option show-trace true \
-  --option connect-timeout 120 \
-  --option timeout 120 \
-  --option max-silent-time 180 \
-  --fallback
+	--option experimental-features 'nix-command flakes' \
+	--option accept-flake-config true \
+	--option show-trace true \
+	--option connect-timeout 120 \
+	--option timeout 120 \
+	--option max-silent-time 180 \
+	--fallback

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `2c456a9f2451df954f2440fb482d3e1b5c780a8ba209ad053f38017a000b751a`
+Canonical context proxy SHA-256: `37bcdaaead0217941da55193f5748ffd421b521cadd0cabf673a86cbeb4fe898`
 
 Run:
 
@@ -49,9 +49,10 @@ is independent of the current Dendritic storage so the mechanics can evolve.
 Bounded checkpoint, propagation, cache verification, and isolated validation
 may be delegated asynchronously when shared-file ownership is non-overlapping.
 For bootstrap tooling, close over immutable logic/tools through Nix, late-bind
-the writable workspace via argument/environment/local discovery, validate it
+the writable workspace via explicit argument or local discovery, validate it
 before mutation, and preserve a baseline-shell recovery path without devshell
-or PATH assumptions.
+or PATH assumptions. Inherit environment roots only when the tool's state
+contract explicitly requires them.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `8194b06fceb7054562a24080baddaa0fa15834c775b2202a1a5521a9a81796cc`
+Canonical context proxy SHA-256: `f9550df00d89e8ae8ec6df8cfa6798aa5f3ffe1f5c214e18f8147f0097820c19`
 
 Run:
 
@@ -44,6 +44,8 @@ refresh, verify, commit, and push it for the next machine/model to consume.
 During long sessions, periodically make this canonical checkpoint so an
 out-of-file-descriptors cache flush or process restart resumes from recent
 committed context rather than conversation memory.
+Use `nix run .#agent-checkpoint` as the stable checkpoint entry point. Its name
+is independent of the current Dendritic storage so the mechanics can evolve.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `2cbc88532ec5f55ac69085ba1d0ba1052676e966a423eed431fd805623b347c4`
+Canonical context proxy SHA-256: `b10a7cb4762d69e4a1ced414ed4367de1f3517f0c162e98e3afaf076aa6f9aae`
 
 Run:
 
@@ -40,6 +40,14 @@ Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,
 refresh and verify the proxy, and commit the bundle. Conversation, goals, and
 model memory are not sufficient durable records.
+
+Work as the owner's senior implementation contractor. The owner controls
+requirements and accepted tradeoffs; the agent controls investigation,
+technical execution, and proof. For genuine requirement ambiguity, load
+`collaboration` and ask evidence-backed questions with alternatives,
+consequences, and a recommendation. Load `invariants` before defining public
+capability boundaries. Load `rootfs` whenever owner feedback teaches a durable
+new reasoning or collaboration rule.
 
 Current north star: fully and severably land the low-level Home Manager layer,
 push genuinely user-space `nixbook-pro` behavior into it, and prove it with two

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `df99908f701340c9a8c2587de53429e470049c109bfeddc8e012a9001c13d0c1`
+Canonical context proxy SHA-256: `2c456a9f2451df954f2440fb482d3e1b5c780a8ba209ad053f38017a000b751a`
 
 Run:
 
@@ -79,6 +79,8 @@ The frozen predecessor may be deliberately thawed to repair code it still
 owns, then verified, re-pinned, and frozen again. Do not duplicate a capability
 into the bridge merely to carry a repair. This main-based migration line owns
 the sole policy bundle; predecessor-local copies are stale and must be removed.
+Publish frozen/protected branch repairs as final PRs and wait for owner approval
+and merge; move the associated freeze tag only after that approved merge.
 Keep active migration/thaw work in dedicated temporary worktrees until the
 bridge is fully eliminated; remind the owner of this preference before an early
 move into their primary checkout, while allowing an explicit override.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `694f15d791feda17f71bb3d42e6a80b6d8e8bc71aa2b3605ec3708cb57e76655`
+Canonical context proxy SHA-256: `52f16c40175b22360763fc3b2bb2f673ce144e67f70453cce194352828370c6a`
 
 Run:
 
@@ -55,6 +55,8 @@ or PATH assumptions. Inherit environment roots only when the tool's state
 contract explicitly requires them.
 Exported environment is an implicit process-tree software bus; publish onto it
 only for an intentional consumer contract, otherwise keep state shell-local.
+Nix-direnv reload is intentionally manual to avoid reload churn; Lorri remains
+an exploratory asynchronous shell-state publisher, not settled bootstrap policy.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,636 @@
+# Dendritic migration: authoritative agent handoff
+
+Read this entire file before changing architecture, rebasing, deleting legacy
+modules, or proposing a migration plan. This is both a project charter and an
+operational handoff for future Codex/model versions. Do not reduce it to a
+generic "modernize the Nix flake" task.
+
+## Mission and stopping condition
+
+The long-lived `dendritic` feature branch cannot land as one repository-wide
+rewrite. Incrementally land its architecture on `main`, beginning with the full
+logical closure of `nixbook-pro`, and leave a bridge on `main` through which
+later sessions can port coherent slices from `dendritic` without repeating its
+structural-rebase problem. Continue the epic until the remaining machine
+closures have been migrated.
+
+The immediate sequence is:
+
+1. finish a behavioral and architectural diff of the complete old and new
+   `nixbook-pro` closures;
+2. polish the low-level Home Manager experience until it is independently
+   landable and production quality;
+3. derive an explicit dependency graph and concrete commit plan;
+4. create a bridge commit on `main` that permits legacy and Dendritic structures
+   to coexist;
+5. port capability lanes and machine closures in coherent, verified commits.
+
+Do not call the migration complete because `nixbook-pro` evaluates, because a
+subset of tests pass, or because the branch is mergeable. Completion means the
+architecture and subsequent machine ports described here are actually landed
+and verified.
+
+## Authoritative architectural intent
+
+Systems are to be reconstructed from imports of capability interfaces, not
+from host-shaped or platform-shaped implementation bundles.
+
+Each capability owns a virtual module namespace. By convention the virtual
+namespace has the same name as the module/capability. Treat the namespace as a
+vTable:
+
+- consumers program against the virtual interface;
+- concrete backends are derived implementations beneath that interface;
+- presets select implementations and defaults but are not interfaces;
+- integrations implement relationships between two capabilities and should be
+  separately severable where either endpoint can exist without the other.
+
+For example, a picker consumer should request candidate production, preview,
+view, or edit operations. It should not construct FZF commands. FZF is one
+backend for the picker vTable; FD, Bat, and Helix integrations populate parts of
+the contract. Likewise, a consumer of a browser should depend on the logical
+browser/open operation, not directly on Zen or its installation mechanism.
+
+The required properties are:
+
+- interface declarations are severable from backend implementations;
+- a backend can be replaced without editing its consumers;
+- integrations are explicit and independently severable;
+- disabling a backend removes its packages from the realized derivation
+  closure;
+- source, evaluation, and derivation closure are distinct concepts;
+- evaluation scope should also remain lightweight, even where Nix laziness
+  keeps a package out of the realized derivation closure;
+- module composition remains transitively lightweight: importing a composition
+  must not silently acquire unrelated capabilities;
+- a virtual namespace corresponds to one stable atomic capability, not merely
+  to a small file;
+- host modules contain machine facts, explicit policy selections, and genuine
+  exceptions rather than reusable implementations;
+- platform modules dispatch or realize capability intent; they should not be
+  the only place the intent can be expressed.
+
+### Closure-discipline priority and accepted dispatch cost
+
+Do not flatten every kind of minimality into one metric. The intended priority
+is roughly:
+
+1. **flake-input graph discipline**: ruthlessly deduplicate inputs, use explicit
+   `follows`, use auto-follow machinery where appropriate, and prune unused lock
+   nodes;
+2. **derivation/runtime closure minimality**: disabled or unrelated
+   implementations must not be installed or retained by the built result;
+3. **module-level severability**: consumers, interfaces, implementations, and
+   integrations must be independently composable at the correct capability
+   boundary;
+4. **evaluation minimality**: desirable, measured, and improved, but the lowest
+   priority of these closure disciplines.
+
+Some evaluation enlargement is the ordinary cost of vTable-like dispatch: the
+evaluator may need the interface, variants, and visitor/dispatch trampoline
+resident in memory so it can choose a backend. Do not contort a clean virtual
+interface merely to eliminate this expected cost. Flag evaluation behavior
+when it forces expensive inputs or implementation values unnecessarily, but
+distinguish that from the acceptable residency needed to make variants
+available for dispatch.
+
+Input minimality is not optional just because evaluation minimality ranks
+lower. The current Dendritic substrate deliberately uses `nix-auto-follow`,
+explicit `inputs.*.follows`, empty follows where an upstream input is genuinely
+unneeded, and `flake-file` lock pruning. Preserve this discipline and verify the
+generated lock graph rather than accepting duplicate Nixpkgs/Home Manager trees
+as incidental flake churn.
+
+There is also a not-yet-realized ambition for flake-parts module-level
+severability/applicability—ideas such as `importApplies` and related machinery.
+Do not claim this exists today. Record cases where flake modules are resident or
+applied too broadly so that a future substrate can make applicability explicit,
+but do not block the HM landing on inventing the entire mechanism first.
+
+Atomicity is semantic. A 150-line backend may be one correct capability. Ten
+five-line files are still a monolith if they always activate together or can
+only be consumed as a bundle.
+
+### Profiles
+
+Profiles are intentionally opinionated presets. They compose through imports
+and enable/default declarations, ordinarily using `mkDefault` so callers can
+replace selections. Do not criticize a profile merely for choosing Bash,
+Helix, FZF, Kitty, or Zen. Do flag a profile if selecting one intended lane
+activates unrelated capabilities or prevents backend substitution.
+
+Keep these categories conceptually distinct:
+
+1. interface modules define vTables/contracts;
+2. backend modules realize a contract;
+3. integration modules connect contracts;
+4. profiles/presets import coherent capability sets and select defaults;
+5. hosts supply machine facts and exceptional policy.
+
+The highest-level interfaces and presets are expected to be the least mature.
+Do not prematurely freeze them merely to make the current tree look finished.
+
+### First polished landing: low-level Home Manager
+
+The shell work establishes the intended pattern even though its feature set is
+not finished. The first production-quality landing should be the low-level Home
+Manager substrate: shell, picker, programs, editor, terminal, identity/secrets,
+and their backends and integrations. High-level browser, application-store,
+dock, desktop, and final workstation taxonomy can remain exploratory while this
+substrate is stabilized.
+
+For the HM substrate, require at least:
+
+- interfaces that do not select implementations;
+- backend `enable` separate from `default` where multiple active backends or a
+  default role are meaningful;
+- integrations that do not unexpectedly enable both endpoints;
+- disabled backend packages absent from derivation closures;
+- backend-only package universes, including unstable Nixpkgs, not forced merely
+  by interface availability where practical;
+- minimal, interactive, development, and standalone compositions tested
+  separately;
+- the same capability modules usable by standalone HM and system-integrated HM;
+- no consumer knowledge of FZF/Helix/Kitty/etc. when a logical contract is
+  sufficient.
+
+## `ezConfigs` and flake composition
+
+`ezConfigs` is legacy infrastructure, not a migration target. It was useful on
+`main` because it discovered host/home modules and coupled user Home Manager
+modules into system configurations. Dendritic composition makes that machinery
+unnecessary and it is not a good architectural fit.
+
+Do not preserve, port, wrap, or recreate `ezConfigs` merely for compatibility.
+Its old behavior must be understood when calculating the old logical closure,
+but the new system should express that behavior directly through virtual
+modules and imports.
+
+Do not assume another existing flake-parts host/configuration interface is the
+desired replacement. None is currently known to fit this architecture well.
+`flake-parts` may still provide the flake module substrate, and `flake-file` plus
+`import-tree` currently provide generated-input and Dendritic module discovery,
+but host composition belongs to the project's own capability modules.
+
+## Branch topology and migration hazard
+
+At the time this handoff was written:
+
+- working branch: `dendritic` at `5940c9bf` before this handoff commit;
+- remote tracking branch: `origin/dendritic` at the same commit;
+- `main` at `315488c2` in the primary repository branch listing;
+- a separate worktree at `./main` is on `general-longstanding-cleanup` at
+  `6e2ecfb4` and must not be mistaken for the `main` branch;
+- merge base between `main` and `dendritic`: `f851783b`;
+- `dendritic` was reconstructed through roughly one hundred small sequential
+  commits, beginning with `Clean everything out` and rebuilding the flake and
+  modules from a blank baseline.
+
+Always re-check these facts. They are historical coordinates, not permanent
+truth. Use `git status --short --branch`, `git branch -vv`, `git worktree list`,
+and `git merge-base main dendritic` before acting.
+
+The branches also differ in dependency era. Current `main` has moved to 26.05
+inputs in its generated flake, while `dendritic` currently uses 25.11 for
+Nixpkgs, Home Manager, and nix-darwin. Never treat lockfiles or generated
+`flake.nix` as mechanically interchangeable. Do not solve this with a giant
+rebase. The bridge must make coexistence and incremental ports possible.
+
+The Dendritic branch's broad diff (previously measured as 475 files, about 6,374
+insertions and 12,402 deletions) is a consequence of reconstruction, not a
+reasonable landing unit. Avoid deleting unrelated legacy hosts or modules as a
+side effect of landing `nixbook-pro`.
+
+## Correct definition of the old `nixbook-pro` logical closure
+
+Do not inspect only `configurations/darwin/nixbook-pro`.
+
+On `main`, `flakeModules/ezConfigs/flake-module.nix` declares:
+
+```nix
+ezConfigs.darwin.hosts.nixbook-pro.userHomeModules = ["krad246"];
+```
+
+That injects `configurations/home/krad246.nix` into the host. The old logical
+closure therefore contains both:
+
+1. direct Darwin roots:
+   - `configurations/darwin/nixbook-pro/default.nix`;
+   - `configuration.nix`;
+   - `remotes.nix`;
+   - Darwin `apps`, `base-configuration`, `colima`, `macos-container`, and
+     `tailscale` imports;
+2. the user HM root:
+   - `configurations/home/krad246.nix`;
+   - `homeModules.base-home` and every transitive import;
+   - generic Cachix, Nix core, flake registry, and home-link registry modules.
+
+The old host also adds a host-local HM import enabling Codex from unstable.
+
+Trace actual option definitions and the merged module result. Similar filenames
+or namespaces are not evidence of behavioral parity.
+
+## Current Dendritic `nixbook-pro` root and composition
+
+`modules/hosts/nixbook-pro/configuration.nix` creates
+`flake.darwinConfigurations.nixbook-pro` and imports:
+
+```text
+darwin.workstation
+├── darwin.applications
+├── darwin.base
+│   ├── home-manager
+│   ├── input-registry
+│   ├── nix
+│   ├── nixpkgs-instance
+│   └── owner
+├── darwin.desktop
+│   ├── app-stores
+│   ├── browser
+│   └── homeManager.desktop for owner
+├── darwin.dev
+│   └── homeManager.dev for owner
+└── darwin.secrets
+    └── homeManager.secrets for owner
+
+darwin.linux-builder
+darwin.tailscale
+host-specific inline modules
+```
+
+The owner HM composition reaches:
+
+```text
+homeManager.base
+├── identity
+├── input-registry
+└── shell
+
+homeManager.desktop
+├── browser
+└── terminal
+
+homeManager.dev
+├── editor
+└── shell.profiles.dev
+
+homeManager.secrets
+└── RBW backend
+```
+
+The host-specific inline modules currently own the aarch64-darwin platform,
+hostname, UID/GID, Bash login shell, DNS/network naming, Nix daemon exceptions,
+deep-cache tuning, trusted owner, Touch ID, macOS updates, and Linux-builder VM
+sizing.
+
+## Strongest architectural results so far
+
+### Shell/picker/program composition
+
+This is the reference pattern. Important layers include:
+
+- `shell.profiles.interactive` and `shell.profiles.dev`: preset policy;
+- `shell.programs.*`: logical tool capabilities;
+- `shell.backends.bash` and `.nushell`: concrete shells;
+- `picker`: logical sources, actions, and bindings;
+- `picker.backends.fzf`: concrete picker;
+- narrowly scoped integrations such as FZF-FD, FZF-Bat, FZF-Helix,
+  Delta-Git, Delta-Lazygit, Git-GH, Git-Kitty, Bash-Yazi, etc.
+
+The picker interface's sources/actions are a better boundary than exposing FZF
+command fragments to consumers. Preserve and extend that pattern.
+
+There are still rough edges. Some program modules are aliases directly onto HM
+`programs.*.enable`, the shell base wires many defaults, and package/evaluation
+laziness has not been systematically proven. Treat shell as the pattern source,
+not as finished code immune from audit.
+
+### Remote Linux builder
+
+The old `base-configuration/linux-builder.nix` combined public options,
+nix-darwin realization, guest NixOS configuration, binfmt, ccache, packages,
+swap, TERM, coredumps, and VM sizing.
+
+The current structure separates:
+
+- `remoteBuilder`: generic interface;
+- `remoteBuilder.backends.linux-builder`: Darwin/nix-darwin backend;
+- `nixos.remote-builder`: reusable guest preset;
+- host-provided `remoteBuilder.configuration`: deferred guest overrides.
+
+This is architecturally strong and demonstrates composition across a nested
+system boundary. Functional parity remains unproven and must cover advertised
+systems, binfmt, ccache, swapspace/static swap, zram, VM cores/RAM/disk,
+maxJobs, TERM, bottom, coredumps, and protocol.
+
+## Explicit owner decisions: do not reopen without new direction
+
+- Arc is removed.
+- LaunchControl is removed.
+- Zen is retained.
+- Discord is added.
+- Colima is intentionally excluded from this port.
+- `macos-container` is intentionally excluded from this port.
+- Using Nixpkgs `bashInteractive` instead of the Homebrew Bash is acceptable for
+  the narrowed slice.
+- Homebrew itself is not forbidden. It may remain or return behind a sound
+  capability; it was initially narrowed out because of porting friction.
+- Profiles are presets and may compose through imports and enable/default
+  declarations.
+
+## Explicitly unfinished or exploratory areas
+
+Do not mistake existence for endorsement:
+
+- remote definitions for `dullahan`, `gremlin`, and `fortress` are missing
+  because their lane still needs rearchitecture; their disappearance is not an
+  accepted feature removal;
+- `appStore` has had effectively zero serious interface-design thought and is
+  exploratory;
+- browser and related high-level interfaces are exploratory;
+- dock may be half-baked;
+- the highest-level profiles/interfaces are generally the least baked;
+- evaluation-scope enlargement is known and should be recorded, prioritized,
+  and fixed after/alongside derivation-closure correctness;
+- every old `base-configuration` behavior must be checked explicitly.
+
+Do not expend early work defending or polishing app-store/browser/dock APIs as
+if they were settled. First use closure evidence to determine their correct
+capability boundaries.
+
+## Behavioral parity ledger (evidence as of this handoff)
+
+Status meanings:
+
+- **preserved**: evidence establishes equivalent effective behavior;
+- **static match**: source mappings look equivalent, but evaluated output still
+  needs proof;
+- **accepted change**: owner explicitly accepts the difference;
+- **missing**: legacy behavior is in the old closure and has no current
+  realization;
+- **unverified**: replacement exists but parity is not proven;
+- **irrelevant**: old module contributed no active behavior;
+- **superseded**: a deliberately different capability fulfills the intent, with
+  details still subject to parity audit.
+
+### Host and Darwin base
+
+| Legacy responsibility | Status | Current evidence / required follow-up |
+|---|---|---|
+| macOS automatic updates | preserved | Set directly in current host. |
+| hostname, localHostName, computerName | preserved | Set from `networking.hostName`. |
+| Cloudflare and Google IPv4/IPv6 DNS | preserved | Same values set by host. |
+| `NIX_REMOTE=daemon` | preserved | Set by host. |
+| `auto-allocate-uids=false` | preserved | Set by host. |
+| `auto-optimise-store=false` | preserved | Set by host. |
+| `/nix/store` extra sandbox path | preserved | Set by host. |
+| `keep-derivations=true` | preserved | Set by host. |
+| `max-substitution-jobs=60` | preserved | Set by host. |
+| owner UID/GID 501/20 | preserved | Host sets user IDs. |
+| primary owner, description, home | static match | `darwin.owner` supplies these; evaluate final user record. |
+| trusted owner | preserved | Host sets `nix.settings.trusted-users`. |
+| Touch ID for sudo | preserved | Set by host. |
+| nixbld GID 350 | preserved | Current `darwin.nix`. |
+| system Agenix module and custom Agenix package | missing | `darwin.secrets` only bridges HM RBW; it does not import `darwin.agenix` or install the prior tool. Decide desired system/HM secret capabilities. |
+| firewall | irrelevant | Old file contained comments only. |
+| system terminal fonts | missing | Old `fonts.packages = pkgs.krad246.term-fonts.paths`; no equivalent found in current host cone. |
+| HM bridge package universe | changed/unverified | Old had `useGlobalPkgs=true`, `useUserPackages=true`, `verbose=false`; new leaves global pkgs off, uses user packages, and is verbose. Audit package identity/overlays/unfree effects before choosing policy. |
+| Homebrew substrate | changed/unverified | Old imported nix-homebrew but defaulted it and Homebrew off, still added `mas` and prefix/shell declarations. Current app-store selection activates Homebrew. Compare effective behavior, not declarations. |
+| guest login disabled | missing | Old master-user module set `GuestEnabled=false`; current lock-screen modules are empty. |
+| console access disabled | missing | Old set `DisableConsoleAccess=true`; no current realization found. |
+| screensaver password | missing | Old set `screensaver.askForPassword=true`; current screensaver module is empty. |
+| custom preference dispatch | unverified | Old copied `CustomUserPreferences` to `CustomSystemPreferences`; new HM Darwin target writes domains through `targets.darwin.defaults`. Compare generated activation/defaults behavior. |
+| dark mode | static match | New desktop defaults request dark, nonautomatic style. Evaluate. |
+| Finder settings | static match | Hidden/extensions, desktop, search scope, view, trash cleanup, path/status bars, POSIX title, folders-first are mapped. |
+| menu/dialog preferences | static match | Expanded save/print panels, table mode, visible menu bar mapped. |
+| pointer/trackpad | static match | Flat mouse acceleration, non-natural scrolling, right-click, corner/scaling values represented. |
+| Spotlight order | static match | Same explicit ordered list exists in Darwin HM dispatcher. |
+| window manager/spaces | mostly static match | Old values represented; evaluate exact domains/types. |
+| Dock constants | mostly static match | Old autohide, magnification, tile size, corners, recents, etc. represented. |
+| Dock apps | partial | Old pinned iPhone Mirroring + Launchpad, and host prepended Zen. New defaults request logical browser, phone-mirroring, launchpad, file-manager, terminal, editor. Darwin dispatcher only maps browser/phone/launchpad, filtering unknown IDs, so effective list is Zen + phone + launchpad. Confirm ordering and whether omitted logical roles need real backends. |
+| Tailscale | static match | Darwin service enabled. |
+| Linux builder | superseded/unverified | Better architecture; perform detailed parity evaluation. |
+| Dullahan/Gremlin/Fortress remotes | missing | Must be redesigned as capability/backends, not copied as host bundle. |
+
+### Applications and accepted removals
+
+Old apps included Arc, Bluesnooze, GroupMe, LaunchControl, Magnet, Signal, UTM,
+Zen, and Zoom. Current application declarations add Discord and preserve most of
+that set through symbolic variants, but centralized tool policy selects no Arc
+and no LaunchControl. Those two removals and Discord addition are accepted.
+
+The current application-store design has known flaws, not migration invariants:
+
+- `appStore.tools.<tool>.enable` conflates availability with activation;
+- the `applications` preset enables all tools rather than deriving activation
+  from selected/resolved demand;
+- Homebrew/`mas`/unfree policy can therefore enter a closure too broadly;
+- selection is a closed central mapping, so a newly declared logical
+  application is ignored until that mapping changes;
+- variant and resolved values are weakly typed (`anything`-like contracts);
+- installation policy, backend availability, backend activation, and logical
+  application declaration are insufficiently separated.
+
+Do not preserve these flaws for compatibility. Redesign after understanding
+actual machine/application lanes.
+
+### Home Manager legacy closure: required audit
+
+This audit is not finished. The old `krad246` HM root sets username/home from
+the OS user, overrides Git email to `condor-janitor0e@icloud.com`, and imports:
+
+- complete `base-home`;
+- `krad246-cachix`;
+- generic Nix core;
+- flake registry;
+- home-link registry.
+
+`base-home` imports Agenix, Bash, Bat, Bitwarden/RBW, Bottom, Direnv, FD, FZF,
+Git, Helix, LSD, terminal fonts, packages, Ripgrep, Spotify Player, Starship,
+Yazi, Zoxide, and Zsh. It also owns activation, XDG, manuals, state version, and
+dotfiles behavior.
+
+The next agent must make a row-by-row old/new ledger for at least:
+
+- identity name/username/email and the special Git email override;
+- Agenix HM module and package versus RBW capability;
+- Cachix configuration;
+- Nix settings and package universe;
+- flake registry and home/system link registries;
+- Bash behavior: vi mode, completion, VTE, Ctrl-H, reload alias, history rules,
+  `tldr`, Yazi wrapper, Kitty/FZF image preview integration;
+- Zsh behavior and whether its removal/nonselection is intentional;
+- Bat theme, extras, aliases, BATDIFF/LESSOPEN/BATPIPE behavior;
+- Bottom Linux desktop hiding;
+- Direnv/nix-direnv and per-shell integrations;
+- FD hidden/default options;
+- old FZF widgets, bindings, preview/view/edit commands, and source semantics;
+- Git identity, LFS, aliases, delta, GH credentials, Kitty integrations;
+- Helix package (`evil-helix` currently), languages, settings, keymaps, and FZF
+  editor integration;
+- LSD colors, hyperlinking, aliases, and shell integration;
+- terminal font packages and Linux fontconfig;
+- package lists, including lost/added tools (`safe-rm`, `procs`, `has`, etc.);
+- Ripgrep and ripgrep-all;
+- Spotify Player (apparently absent in current cone);
+- Starship settings and shell integration;
+- Yazi settings/keymaps/integrations;
+- Zoxide integrations;
+- Codex moved from host-local import to development preset;
+- old dotfiles sync activation and out-of-store link behavior;
+- manual HTML/JSON behavior, including old Zen manual opener behavior;
+- XDG configuration and Home Manager state version.
+
+For each item classify preserved, accepted change, missing, irrelevant, or
+unverified and cite exact option/config evidence. Do not infer parity from a new
+file having the same tool name.
+
+## Known closure/evaluation concerns
+
+Use three separate measurements:
+
+1. **source closure**: files/modules discovered or imported;
+2. **evaluation closure**: inputs, package sets, and module values forced while
+   evaluating;
+3. **derivation/runtime closure**: store paths reachable from built results.
+
+Primary acceptance requires disabled implementations to stay out of derivation
+closures. Evaluation lightness remains part of the vision and must be improved
+in prioritized passes, but it is deliberately lower priority than input-graph
+discipline, derivation closure, and sound interface severability. A resident set
+of backend variants plus dispatch machinery can be an acceptable vTable tax.
+
+Examples already observed:
+
+- Kitty imports `nixpkgs-unstable` and assigns `pkgs.unstable.kitty` even when
+  its backend is disabled. Laziness may keep Kitty out of the derivation, but
+  mere backend availability can enlarge evaluation scope.
+- Bottom, Lazygit, and Codex similarly select unstable packages in modules that
+  may be imported before enablement.
+- Interface declarations should remain available without forcing backend-only
+  package sets where possible.
+- Importing an integration must not silently install both endpoints unless the
+  profile explicitly requests both.
+
+Create real checks/fixtures rather than relying on source inspection. A useful
+matrix includes bare HM interface, minimal shell, interactive shell, dev shell,
+each backend disabled/enabled, standalone HM, system-integrated HM, and backend
+replacement. Inspect derivation references or closure paths for forbidden
+packages.
+
+## Acceptance gates for the `nixbook-pro` slice
+
+All of these remain required unless the owner explicitly revises them:
+
+- `nixbook-pro` evaluates and builds independently;
+- its nested Linux-builder guest evaluates independently;
+- disabled backends do not enter derivation closures;
+- replacing Bash, Helix, FZF, Kitty, Zen, or an application installation tool
+  does not require editing consumers;
+- profile composition does not activate unrelated capabilities;
+- every imported capability is used or required to expose a stable consumed
+  interface;
+- all functional deviations from `main` are explicit and accepted;
+- Colima and `macos-container` remain intentionally excluded;
+- application tools eventually activate from resolved demand, not mere
+  availability;
+- remote-machine definitions are rearchitected rather than silently lost;
+- the slice can merge without deleting unrelated legacy hosts/closures;
+- the low-level HM layer has standalone and integrated composition evidence;
+- input-version differences are resolved intentionally, not hidden by lockfile
+  churn.
+
+## Bridge-to-main constraints
+
+The bridge is not yet designed. Derive it from the completed closure ledger,
+but preserve these constraints:
+
+- it must land on current `main`, not make `main` adopt the reconstructed
+  Dendritic tree wholesale;
+- legacy configurations must continue to work while individual lanes move;
+- new virtual module namespaces must be introducible alongside old
+  `darwinModules`, `homeModules`, and `nixosModules` exports;
+- avoid requiring `ezConfigs` for new configurations;
+- do not delete old modules until every consuming closure has moved;
+- generated `flake.nix`/`flake.lock` changes must be isolated and explainable;
+- commit boundaries should follow dependency cones and leave the flake
+  evaluable;
+- prefer a substrate/registry bridge followed by low-level HM lanes, profiles,
+  system adapters, and host roots—not a cherry-pick of historical reconstruction
+  commits whose context assumes the blanked tree;
+- record old-to-new behavior decisions so future ports are closure migrations,
+  not archaeology repeats.
+
+A likely sequence, subject to evidence, is:
+
+1. Dendritic virtual-module/export substrate compatible with existing outputs;
+2. inputs/Nixpkgs/Home Manager foundations required by the HM cone;
+3. identity and low-level shell program interfaces;
+4. shell backends and explicit integrations;
+5. editor/terminal capabilities and standalone HM fixtures;
+6. provisional presets using `mkDefault`;
+7. Darwin owner/HM adapters and narrowly needed desktop behavior;
+8. remote-builder interface/backend/guest;
+9. `nixbook-pro` root;
+10. later remote, application, desktop, and other machine lanes.
+
+Do not treat this likely sequence as approved implementation detail until the
+audit and dependency graph establish exact commits.
+
+## Working protocol for future agents
+
+At the start of every continuation:
+
+1. read this file completely;
+2. inspect `git status --short --branch`, branches, worktrees, and recent logs;
+3. treat current files and evaluated outputs as authoritative over historical
+   statements in this handoff;
+4. update stale coordinates in this file when making a durable architectural
+   commit;
+5. resume the closure ledger before inventing a plan from memory.
+
+While analyzing:
+
+- use `git show main:path` to inspect legacy sources without switching branches;
+- use `rg`/`git grep` to trace imports and option assignments;
+- inspect the actual old root wiring, including invisible framework injection;
+- distinguish static source similarity from evaluated parity;
+- record accepted changes separately from accidental omissions;
+- avoid changing exploratory interfaces merely to make the audit cleaner.
+
+Before editing:
+
+- produce the exact transitive dependency cone for the intended slice;
+- check for user changes and preserve them;
+- explain whether the edit advances interface severability, backend
+  replaceability, closure lightness, composability, parity, or bridgeability;
+- reject changes that merely reproduce the old bundle under new names.
+
+Before committing:
+
+- inspect the diff and commit only the intended slice;
+- run evaluation/build checks proportional to the closure changed;
+- include negative closure tests for backend disablement where relevant;
+- do not claim broad parity from `nix flake check --no-build` alone;
+- update this handoff when a decision, status, branch coordinate, or next step
+  materially changes.
+
+## Immediate next work
+
+1. Finish the HM program-by-program behavioral ledger listed above.
+2. Evaluate the old and new `nixbook-pro` configurations where feasible and
+   capture normalized option/output diffs, separating dependency-version drift
+   from architectural changes.
+3. Complete Linux-builder parity and independent guest evaluation.
+4. Inventory remote definitions by intent so a capability interface can be
+   designed later; do not copy `krad246.remotes.*` wholesale.
+5. Audit the current HM module graph for implicit activation and unstable-input
+   evaluation leaks.
+6. Define standalone HM composition/closure tests.
+7. From that evidence, write the concrete coexistence bridge and commit graph.
+8. Only then implement the bridge on current `main` and begin port commits.
+
+The key mental model is: this is not a file migration, a naming cleanup, or a
+large rebase. It is the incremental extraction and landing of composable
+capability vTables and their derived backends, proven through the real closure
+of a machine.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `b10a7cb4762d69e4a1ced414ed4367de1f3517f0c162e98e3afaf076aa6f9aae`
+Canonical context proxy SHA-256: `5601142cf07845736fedf4beaafdf64abe350f02475df7cf324da7fb7dd582ab`
 
 Run:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `bf219374e8ae33a9043c4b595ab59c304075e10e9e46197526b0c568a430669f`
+Canonical context proxy SHA-256: `85bef7edc0a846bf4526898267c45db9925ffca8dfdc5c42f7e2c9517693d456`
 
 Run:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `52f16c40175b22360763fc3b2bb2f673ce144e67f70453cce194352828370c6a`
+Canonical context proxy SHA-256: `281c4396d9d1aa3f21dbe9fe67f68c01c12aaedd574bf4ed99e8cac2f2287f78`
 
 Run:
 
@@ -57,6 +57,14 @@ Exported environment is an implicit process-tree software bus; publish onto it
 only for an intentional consumer contract, otherwise keep state shell-local.
 Nix-direnv reload is intentionally manual to avoid reload churn; Lorri remains
 an exploratory asynchronous shell-state publisher, not settled bootstrap policy.
+Parallel agents own distinct worktrees and branches; verify the remote tip and
+publish with `git push --force-with-lease --atomic`, never to a shared branch.
+Legacy Generic Linux behavior is decision evidence, not automatic parity scope:
+inventory and classify deltas, then require owner retain/redesign/drop decisions.
+Kitty is a backend candidate for a multi-backend terminal interface, not the
+portable interface itself.
+VS Code and VS Code server integration are deferred outside current migration
+scope and are not parity or deletion gates.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `f2226cfd8f64f57e18c90561ab17db2ae93fb418b7049c8d0606c802bd3fcba3`
+Canonical context proxy SHA-256: `bf219374e8ae33a9043c4b595ab59c304075e10e9e46197526b0c568a430669f`
 
 Run:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `b9bc27a4ffecc6c690c794926a7f69d768b14c66c6bdb02ee7aa69896d79f951`
+Canonical context proxy SHA-256: `398b17f08cd459d3c96e24dc11f8ab9b411f879c750c84445dd13ab4fb8a6eda`
 
 Run:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `85bef7edc0a846bf4526898267c45db9925ffca8dfdc5c42f7e2c9517693d456`
+Canonical context proxy SHA-256: `47a59104aaf785777da997888bff79c0c7c94dbebaba31582d50d25474e3e416`
 
 Run:
 
@@ -35,6 +35,12 @@ index. After changing either, run `.agents/dendritic/context.sh refresh` and
 commit the canonical files, manifest, and regenerated root `AGENTS.md` together.
 A verification mismatch means this proxy is stale: stop and refresh or inspect
 the canonical diff. Never reconstruct intent from the hash itself.
+
+Local Codex project-charter caches are mirrors, not an authority. `refresh`
+also updates them. After cloning or pulling on another computer, run
+`.agents/dendritic/context.sh sync-cache` and `verify-cache`. Never leave a
+cache-only architectural mutation: reconcile it into the canonical bundle,
+refresh, verify, commit, and push it for the next machine/model to consume.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `398b17f08cd459d3c96e24dc11f8ab9b411f879c750c84445dd13ab4fb8a6eda`
+Canonical context proxy SHA-256: `8194b06fceb7054562a24080baddaa0fa15834c775b2202a1a5521a9a81796cc`
 
 Run:
 
@@ -66,3 +66,8 @@ real consumers—nix-darwin-integrated HM and standalone HM—before hardening t
 less-mature high-level interfaces. A coexistence bridge on current `main` is a
 mandatory early deliverable: use it to move the epic to trunk-based incremental
 ports rather than growing another unmergeable Dendritic branch.
+
+The frozen predecessor may be deliberately thawed to repair code it still
+owns, then verified, re-pinned, and frozen again. Do not duplicate a capability
+into the bridge merely to carry a repair. This main-based migration line owns
+the sole policy bundle; predecessor-local copies are stale and must be removed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `47a59104aaf785777da997888bff79c0c7c94dbebaba31582d50d25474e3e416`
+Canonical context proxy SHA-256: `b9bc27a4ffecc6c690c794926a7f69d768b14c66c6bdb02ee7aa69896d79f951`
 
 Run:
 
@@ -41,6 +41,9 @@ also updates them. After cloning or pulling on another computer, run
 `.agents/dendritic/context.sh sync-cache` and `verify-cache`. Never leave a
 cache-only architectural mutation: reconcile it into the canonical bundle,
 refresh, verify, commit, and push it for the next machine/model to consume.
+During long sessions, periodically make this canonical checkpoint so an
+out-of-file-descriptors cache flush or process restart resumes from recent
+committed context rather than conversation memory.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `b3f950070e885d0531fa6b9b6c7b87e3aa88b5eabcdc41b3a931d426aa73520b`
+Canonical context proxy SHA-256: `2cbc88532ec5f55ac69085ba1d0ba1052676e966a423eed431fd805623b347c4`
 
 Run:
 
@@ -35,6 +35,11 @@ index. After changing either, run `.agents/dendritic/context.sh refresh` and
 commit the canonical files, manifest, and regenerated root `AGENTS.md` together.
 A verification mismatch means this proxy is stale: stop and refresh or inspect
 the canonical diff. Never reconstruct intent from the hash itself.
+
+Owner decisions that pivot architecture must be synchronized immediately. Load
+the `decision-sync` route, update every affected canonical statement/ledger/gate,
+refresh and verify the proxy, and commit the bundle. Conversation, goals, and
+model memory are not sufficient durable records.
 
 Current north star: fully and severably land the low-level Home Manager layer,
 push genuinely user-space `nixbook-pro` behavior into it, and prove it with two

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `f9550df00d89e8ae8ec6df8cfa6798aa5f3ffe1f5c214e18f8147f0097820c19`
+Canonical context proxy SHA-256: `1861fd3716c130c89b28ae755af620a2b5845f00ecb642ca3a3154ed68d4a166`
 
 Run:
 
@@ -46,6 +46,8 @@ out-of-file-descriptors cache flush or process restart resumes from recent
 committed context rather than conversation memory.
 Use `nix run .#agent-checkpoint` as the stable checkpoint entry point. Its name
 is independent of the current Dendritic storage so the mechanics can evolve.
+Bounded checkpoint, propagation, cache verification, and isolated validation
+may be delegated asynchronously when shared-file ownership is non-overlapping.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,
@@ -73,3 +75,6 @@ The frozen predecessor may be deliberately thawed to repair code it still
 owns, then verified, re-pinned, and frozen again. Do not duplicate a capability
 into the bridge merely to carry a repair. This main-based migration line owns
 the sole policy bundle; predecessor-local copies are stale and must be removed.
+Keep active migration/thaw work in dedicated temporary worktrees until the
+bridge is fully eliminated; remind the owner of this preference before an early
+move into their primary checkout, while allowing an explicit override.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `5601142cf07845736fedf4beaafdf64abe350f02475df7cf324da7fb7dd582ab`
+Canonical context proxy SHA-256: `f2226cfd8f64f57e18c90561ab17db2ae93fb418b7049c8d0606c802bd3fcba3`
 
 Run:
 
@@ -46,8 +46,10 @@ requirements and accepted tradeoffs; the agent controls investigation,
 technical execution, and proof. For genuine requirement ambiguity, load
 `collaboration` and ask evidence-backed questions with alternatives,
 consequences, and a recommendation. Load `invariants` before defining public
-capability boundaries. Load `rootfs` whenever owner feedback teaches a durable
-new reasoning or collaboration rule.
+capability boundaries. Load `proof-budget` before rechecking a downstream fact
+already guaranteed by platform, overlay, input, or interface composition. Load
+`rootfs` whenever owner feedback teaches a durable new reasoning or
+collaboration rule.
 
 Current north star: fully and severably land the low-level Home Manager layer,
 push genuinely user-space `nixbook-pro` behavior into it, and prove it with two

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `37bcdaaead0217941da55193f5748ffd421b521cadd0cabf673a86cbeb4fe898`
+Canonical context proxy SHA-256: `694f15d791feda17f71bb3d42e6a80b6d8e8bc71aa2b3605ec3708cb57e76655`
 
 Run:
 
@@ -53,6 +53,8 @@ the writable workspace via explicit argument or local discovery, validate it
 before mutation, and preserve a baseline-shell recovery path without devshell
 or PATH assumptions. Inherit environment roots only when the tool's state
 contract explicitly requires them.
+Exported environment is an implicit process-tree software bus; publish onto it
+only for an intentional consumer contract, otherwise keep state shell-local.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,
@@ -75,6 +77,11 @@ real consumers—nix-darwin-integrated HM and standalone HM—before hardening t
 less-mature high-level interfaces. A coexistence bridge on current `main` is a
 mandatory early deliverable: use it to move the epic to trunk-based incremental
 ports rather than growing another unmergeable Dendritic branch.
+
+Treat flake policy as repository execution policy and terraform the lock graph
+incrementally: use meaningful flake-parts partitions, remove inputs only after
+their consumers migrate, deduplicate with explicit follows, and require each
+lock change to correspond to a proven output/capability boundary.
 
 The frozen predecessor may be deliberately thawed to repair code it still
 owns, then verified, re-pinned, and frozen again. Do not duplicate a capability

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `1861fd3716c130c89b28ae755af620a2b5845f00ecb642ca3a3154ed68d4a166`
+Canonical context proxy SHA-256: `df99908f701340c9a8c2587de53429e470049c109bfeddc8e012a9001c13d0c1`
 
 Run:
 
@@ -48,6 +48,10 @@ Use `nix run .#agent-checkpoint` as the stable checkpoint entry point. Its name
 is independent of the current Dendritic storage so the mechanics can evolve.
 Bounded checkpoint, propagation, cache verification, and isolated validation
 may be delegated asynchronously when shared-file ownership is non-overlapping.
+For bootstrap tooling, close over immutable logic/tools through Nix, late-bind
+the writable workspace via argument/environment/local discovery, validate it
+before mutation, and preserve a baseline-shell recovery path without devshell
+or PATH assumptions.
 
 Owner decisions that pivot architecture must be synchronized immediately. Load
 the `decision-sync` route, update every affected canonical statement/ledger/gate,

--- a/configurations/darwin/dullahan/secrets/krad246/secrets.nix
+++ b/configurations/darwin/dullahan/secrets/krad246/secrets.nix
@@ -1,12 +1,2 @@
-let
-  dullahan = {
-    krad246 = {
-    };
-
-    system = {
-    };
-  };
-
-  inherit (dullahan) krad246 system;
-in {
+{
 }

--- a/configurations/darwin/dullahan/secrets/system/secrets.nix
+++ b/configurations/darwin/dullahan/secrets/system/secrets.nix
@@ -8,7 +8,7 @@ let
     };
   };
 
-  inherit (dullahan) system linux-builder;
+  inherit (dullahan) system;
 in {
   "./hercules-ci/headless-penguin/headless-penguin-binary-caches.age".publicKeys = [system.ed25519];
   "./hercules-ci/headless-penguin/headless-penguin-cluster-join-token.age".publicKeys = [system.ed25519];

--- a/configurations/nixos/windex/configuration.nix
+++ b/configurations/nixos/windex/configuration.nix
@@ -58,7 +58,6 @@ in {
 
   home-manager.sharedModules = [
     (inner @ {
-      config,
       lib,
       pkgs,
       ...

--- a/flake.lock
+++ b/flake.lock
@@ -323,11 +323,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786579274,
-        "narHash": "sha256-cLazYmIEToh64MSmKgqfOZpFqvBJB9Pr4BVLRO+I6K8=",
+        "lastModified": 1786596151,
+        "narHash": "sha256-4Q6O9VXnKjXx8ztZxVNCNgc80KVpaFR85WjZU/Ftlrk=",
         "owner": "krad246",
         "repo": "nix-systems",
-        "rev": "0846de2ff19d9c2f22041e8d24b8055b7ac95104",
+        "rev": "b1e091f82a22c8bbb9f1ad99dfed2589cc1d00aa",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -323,11 +323,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786596151,
-        "narHash": "sha256-4Q6O9VXnKjXx8ztZxVNCNgc80KVpaFR85WjZU/Ftlrk=",
+        "lastModified": 1786598930,
+        "narHash": "sha256-aFRP9iz1tOlG0f78k7SmhgAIjIZMxR4zO0e/dsizu1w=",
         "owner": "krad246",
         "repo": "nix-systems",
-        "rev": "b1e091f82a22c8bbb9f1ad99dfed2589cc1d00aa",
+        "rev": "06cece4c1a90af8c79da1b53d3a535dbefaff5ef",
         "type": "github"
       },
       "original": {

--- a/flakeModules/apps/agent-checkpoint.nix
+++ b/flakeModules/apps/agent-checkpoint.nix
@@ -19,6 +19,9 @@ writeShellApplication {
       exit 1
     fi
 
-    bash ${../../.agents/dendritic/context.sh} checkpoint "$root" "$root/.agents/dendritic"
+    bash ${../../.agents/dendritic/context.sh} \
+      --root "$root" \
+      --bundle "$root/.agents/dendritic" \
+      checkpoint
   '';
 }

--- a/flakeModules/apps/agent-checkpoint.nix
+++ b/flakeModules/apps/agent-checkpoint.nix
@@ -1,0 +1,29 @@
+{
+  writeShellApplication,
+  bash,
+  coreutils,
+  gawk,
+  gnused,
+  perl,
+  ...
+}:
+writeShellApplication {
+  name = "agent-checkpoint";
+  runtimeInputs = [bash coreutils gawk gnused perl];
+  text = ''
+    root="''${FLAKE_ROOT:-}"
+    if [[ ! -f "$root/flake.nix" || ! -f "$root/.agents/dendritic/context.md" ]]; then
+      root="$PWD"
+      while [[ "$root" != / && (! -f "$root/flake.nix" || ! -f "$root/.agents/dendritic/context.md") ]]; do
+        root="''${root%/*}"
+      done
+    fi
+
+    if [[ ! -f "$root/flake.nix" || ! -f "$root/.agents/dendritic/context.md" ]]; then
+      printf 'agent-checkpoint: no context-bearing flake found from %s\n' "$PWD" >&2
+      exit 1
+    fi
+
+    bash ${../../.agents/dendritic/context.sh} checkpoint "$root" "$root/.agents/dendritic"
+  '';
+}

--- a/flakeModules/apps/agent-checkpoint.nix
+++ b/flakeModules/apps/agent-checkpoint.nix
@@ -5,22 +5,17 @@
   gawk,
   gnused,
   perl,
+  flake-root,
   ...
 }:
 writeShellApplication {
   name = "agent-checkpoint";
   runtimeInputs = [bash coreutils gawk gnused perl];
   text = ''
-    root="''${FLAKE_ROOT:-}"
-    if [[ ! -f "$root/flake.nix" || ! -f "$root/.agents/dendritic/context.md" ]]; then
-      root="$PWD"
-      while [[ "$root" != / && (! -f "$root/flake.nix" || ! -f "$root/.agents/dendritic/context.md") ]]; do
-        root="''${root%/*}"
-      done
-    fi
+    root="''${1:-$(${flake-root}/bin/flake-root)}"
 
     if [[ ! -f "$root/flake.nix" || ! -f "$root/.agents/dendritic/context.md" ]]; then
-      printf 'agent-checkpoint: no context-bearing flake found from %s\n' "$PWD" >&2
+      printf 'agent-checkpoint: invalid context-bearing flake root: %s\n' "$root" >&2
       exit 1
     fi
 

--- a/flakeModules/apps/bootstrap.nix
+++ b/flakeModules/apps/bootstrap.nix
@@ -27,8 +27,13 @@ writeShellApplication {
     ]
     ++ [nixVersions.stable] ++ [flake-root];
   text = ''
-    TOP="$(flake-root)"
-    direnv allow "$TOP"
-    direnv exec "$TOP" true
+    root="''${1:-$(${flake-root}/bin/flake-root)}"
+    if [[ ! -f "$root/flake.nix" || ! -f "$root/.envrc" ]]; then
+      printf 'bootstrap: invalid flake root: %s\n' "$root" >&2
+      exit 1
+    fi
+
+    ${direnv}/bin/direnv allow "$root"
+    ${direnv}/bin/direnv exec "$root" true
   '';
 }

--- a/flakeModules/apps/flake-module.nix
+++ b/flakeModules/apps/flake-module.nix
@@ -11,7 +11,9 @@
       {
         agent-checkpoint = {
           type = "app";
-          program = lib.meta.getExe (pkgs.callPackage ./agent-checkpoint.nix {});
+          program = lib.meta.getExe (pkgs.callPackage ./agent-checkpoint.nix {
+            flake-root = config.flake-root.package;
+          });
           meta.description = "Checkpoint active agent-maintained context.";
         };
 

--- a/flakeModules/apps/flake-module.nix
+++ b/flakeModules/apps/flake-module.nix
@@ -9,6 +9,12 @@
   }: {
     apps =
       {
+        agent-checkpoint = {
+          type = "app";
+          program = lib.meta.getExe (pkgs.callPackage ./agent-checkpoint.nix {});
+          meta.description = "Checkpoint active agent-maintained context.";
+        };
+
         bootstrap = let
           runner = pkgs.callPackage ./bootstrap.nix {
             flake-root = config.flake-root.package;

--- a/flakeModules/checks/flake-module.nix
+++ b/flakeModules/checks/flake-module.nix
@@ -62,6 +62,25 @@
 
             stages = ["pre-push"];
           };
+          realize-dendritic-hm-base = {
+            enable = true;
+            description = "Realize the Dendritic Home Manager base before pushing";
+
+            # FIXME(dendritic-migration): Delete this hook once the Home Manager
+            # closure has been ported. Discarding the string context keeps hook
+            # installation from realizing the check; pre-push still receives the
+            # exact derivation selected by the already-evaluated checks schema.
+            entry = "${config.packages.nix}/bin/nix-store --realise ${
+              lib.strings.escapeShellArg (
+                builtins.unsafeDiscardStringContext config.checks.dendritic-hm-base.drvPath
+              )
+            }";
+
+            always_run = true;
+            pass_filenames = false;
+
+            stages = ["pre-push"];
+          };
           alejandra.enable = true;
           check-added-large-files.enable = true;
           check-case-conflicts.enable = true;

--- a/flakeModules/dendritic/flake-module.nix
+++ b/flakeModules/dendritic/flake-module.nix
@@ -45,137 +45,9 @@
       modules =
         inputs.dendritic.modules
         // {
-          generic =
-            inputs.dendritic.modules.generic
-            // {
-              input-registry = {
-                config,
-                options,
-                ...
-              }: let
-                cfg = config.input-registry;
-                isHomeManager = options ? home.file;
-              in {
-                options.input-registry = {
-                  registry = {
-                    managed = lib.mkOption {
-                      type = lib.types.bool;
-                      default = true;
-                      description = "Enable the input registry aspect.";
-                    };
-
-                    source =
-                      options.nix.registry
-                      // {
-                        default = let
-                          isFlake = _: lib.types.isType "flake";
-                          toEntry = _: flake: {inherit flake;};
-                        in
-                          lib.pipe inputs [
-                            (lib.filterAttrs isFlake)
-                            (lib.mapAttrs toEntry)
-                          ];
-
-                        readOnly = cfg.registry.locked;
-                      };
-
-                    locked = lib.mkOption {
-                      type = lib.types.bool;
-                      internal = true;
-                      default = !isHomeManager;
-                      readOnly = true;
-                    };
-                  };
-
-                  sysroot = {
-                    install = lib.mkOption {
-                      type = lib.types.bool;
-                      default = false;
-                      description = "Install input registry entries into the filesystem.";
-                    };
-
-                    destination = {
-                      directory = lib.mkOption {
-                        type = lib.types.str;
-                        internal = true;
-                        default =
-                          if isHomeManager
-                          then config.home.homeDirectory
-                          else "/etc";
-                        readOnly = true;
-                      };
-
-                      prefix = lib.mkOption {
-                        type = lib.types.str;
-                        default = "/nix/path";
-                        description = "Subpath under the destination directory for input links.";
-                        apply = value: lib.path.subpath.normalise ("./" + value);
-                      };
-                    };
-
-                    abspath = lib.mkOption {
-                      type = lib.types.str;
-                      internal = true;
-                      readOnly = true;
-                    };
-                  };
-
-                  search-path.enable = lib.mkOption {
-                    type = lib.types.bool;
-                    default = false;
-                    description = "Expose the installed input registry through legacy NIX_PATH.";
-                  };
-                };
-
-                config = lib.mkMerge [
-                  (lib.mkIf cfg.registry.managed {
-                    nix = {
-                      registry = cfg.registry.source;
-                      settings.experimental-features = ["nix-command" "flakes"];
-                    };
-                  })
-                  {
-                    assertions = [
-                      {
-                        assertion = cfg.search-path.enable -> cfg.sysroot.install;
-                        message = "The input-registry search path requires its filesystem projection.";
-                      }
-                    ];
-
-                    input-registry.sysroot.abspath = lib.concatStringsSep "/" [
-                      cfg.sysroot.destination.directory
-                      (lib.removePrefix "./" cfg.sysroot.destination.prefix)
-                    ];
-
-                    nix.nixPath = lib.mkIf cfg.search-path.enable [cfg.sysroot.abspath];
-                  }
-                  (lib.mkIf cfg.sysroot.install (let
-                    prefix = cfg.sysroot.destination.prefix;
-                    links =
-                      lib.mapAttrs' (
-                        name: value: {
-                          name = lib.path.subpath.join [prefix name];
-                          value.source = value.to.path;
-                        }
-                      )
-                      config.nix.registry;
-                    attrPath =
-                      if isHomeManager
-                      then ["home" "file"]
-                      else ["environment" "etc"];
-                  in
-                    lib.setAttrByPath attrPath links))
-                ];
-              };
-            };
-
           homeManager =
             inputs.dendritic.modules.homeManager
             // rec {
-              input-registry = {
-                imports = [modules.generic.input-registry];
-              };
-
               base = {
                 lib,
                 pkgs,
@@ -184,7 +56,6 @@
                 imports = [
                   inputs.dendritic.homeModules.home-manager
                   inputs.dendritic.homeModules.identity
-                  input-registry
                 ];
 
                 config = lib.mkMerge [
@@ -274,12 +145,6 @@
             assert cfg.xdg.enable;
             assert cfg.manual.json.enable;
             assert !cfg.manual.html.enable;
-            assert cfg.input-registry.registry.managed;
-            assert !cfg.input-registry.registry.locked;
-            assert !cfg.input-registry.sysroot.install;
-            assert !cfg.input-registry.search-path.enable;
-            assert cfg.input-registry.sysroot.abspath == "/Users/krad246/nix/path";
-            assert cfg.nix.settings.experimental-features == ["nix-command" "flakes"];
             assert cfg.programs.home-manager.enable;
             assert !cfg.programs.bash.enable;
             assert !cfg.programs.bat.enable;
@@ -300,11 +165,6 @@
             assert cfg.targets.genericLinux.enable;
             assert !cfg.targets.genericLinux.gpu.enable;
             assert cfg.systemd.user.startServices;
-            assert cfg.input-registry.registry.managed;
-            assert !cfg.input-registry.registry.locked;
-            assert !cfg.input-registry.sysroot.install;
-            assert !cfg.input-registry.search-path.enable;
-            assert cfg.input-registry.sysroot.abspath == "/home/krad246/nix/path";
               configuration.activationPackage;
         })
       ];

--- a/flakeModules/dendritic/flake-module.nix
+++ b/flakeModules/dendritic/flake-module.nix
@@ -45,9 +45,137 @@
       modules =
         inputs.dendritic.modules
         // {
+          generic =
+            inputs.dendritic.modules.generic
+            // {
+              input-registry = {
+                config,
+                options,
+                ...
+              }: let
+                cfg = config.input-registry;
+                isHomeManager = options ? home.file;
+              in {
+                options.input-registry = {
+                  registry = {
+                    managed = lib.mkOption {
+                      type = lib.types.bool;
+                      default = true;
+                      description = "Enable the input registry aspect.";
+                    };
+
+                    source =
+                      options.nix.registry
+                      // {
+                        default = let
+                          isFlake = _: lib.types.isType "flake";
+                          toEntry = _: flake: {inherit flake;};
+                        in
+                          lib.pipe inputs [
+                            (lib.filterAttrs isFlake)
+                            (lib.mapAttrs toEntry)
+                          ];
+
+                        readOnly = cfg.registry.locked;
+                      };
+
+                    locked = lib.mkOption {
+                      type = lib.types.bool;
+                      internal = true;
+                      default = !isHomeManager;
+                      readOnly = true;
+                    };
+                  };
+
+                  sysroot = {
+                    install = lib.mkOption {
+                      type = lib.types.bool;
+                      default = false;
+                      description = "Install input registry entries into the filesystem.";
+                    };
+
+                    destination = {
+                      directory = lib.mkOption {
+                        type = lib.types.str;
+                        internal = true;
+                        default =
+                          if isHomeManager
+                          then config.home.homeDirectory
+                          else "/etc";
+                        readOnly = true;
+                      };
+
+                      prefix = lib.mkOption {
+                        type = lib.types.str;
+                        default = "/nix/path";
+                        description = "Subpath under the destination directory for input links.";
+                        apply = value: lib.path.subpath.normalise ("./" + value);
+                      };
+                    };
+
+                    abspath = lib.mkOption {
+                      type = lib.types.str;
+                      internal = true;
+                      readOnly = true;
+                    };
+                  };
+
+                  search-path.enable = lib.mkOption {
+                    type = lib.types.bool;
+                    default = false;
+                    description = "Expose the installed input registry through legacy NIX_PATH.";
+                  };
+                };
+
+                config = lib.mkMerge [
+                  (lib.mkIf cfg.registry.managed {
+                    nix = {
+                      registry = cfg.registry.source;
+                      settings.experimental-features = ["nix-command" "flakes"];
+                    };
+                  })
+                  {
+                    assertions = [
+                      {
+                        assertion = cfg.search-path.enable -> cfg.sysroot.install;
+                        message = "The input-registry search path requires its filesystem projection.";
+                      }
+                    ];
+
+                    input-registry.sysroot.abspath = lib.concatStringsSep "/" [
+                      cfg.sysroot.destination.directory
+                      (lib.removePrefix "./" cfg.sysroot.destination.prefix)
+                    ];
+
+                    nix.nixPath = lib.mkIf cfg.search-path.enable [cfg.sysroot.abspath];
+                  }
+                  (lib.mkIf cfg.sysroot.install (let
+                    prefix = cfg.sysroot.destination.prefix;
+                    links =
+                      lib.mapAttrs' (
+                        name: value: {
+                          name = lib.path.subpath.join [prefix name];
+                          value.source = value.to.path;
+                        }
+                      )
+                      config.nix.registry;
+                    attrPath =
+                      if isHomeManager
+                      then ["home" "file"]
+                      else ["environment" "etc"];
+                  in
+                    lib.setAttrByPath attrPath links))
+                ];
+              };
+            };
+
           homeManager =
             inputs.dendritic.modules.homeManager
             // rec {
+              input-registry = {
+                imports = [modules.generic.input-registry];
+              };
+
               base = {
                 lib,
                 pkgs,
@@ -56,6 +184,7 @@
                 imports = [
                   inputs.dendritic.homeModules.home-manager
                   inputs.dendritic.homeModules.identity
+                  input-registry
                 ];
 
                 config = lib.mkMerge [
@@ -145,6 +274,12 @@
             assert cfg.xdg.enable;
             assert cfg.manual.json.enable;
             assert !cfg.manual.html.enable;
+            assert cfg.input-registry.registry.managed;
+            assert !cfg.input-registry.registry.locked;
+            assert !cfg.input-registry.sysroot.install;
+            assert !cfg.input-registry.search-path.enable;
+            assert cfg.input-registry.sysroot.abspath == "/Users/krad246/nix/path";
+            assert cfg.nix.settings.experimental-features == ["nix-command" "flakes"];
             assert cfg.programs.home-manager.enable;
             assert !cfg.programs.bash.enable;
             assert !cfg.programs.bat.enable;
@@ -165,6 +300,11 @@
             assert cfg.targets.genericLinux.enable;
             assert !cfg.targets.genericLinux.gpu.enable;
             assert cfg.systemd.user.startServices;
+            assert cfg.input-registry.registry.managed;
+            assert !cfg.input-registry.registry.locked;
+            assert !cfg.input-registry.sysroot.install;
+            assert !cfg.input-registry.search-path.enable;
+            assert cfg.input-registry.sysroot.abspath == "/home/krad246/nix/path";
               configuration.activationPackage;
         })
       ];

--- a/flakeModules/dendritic/flake-module.nix
+++ b/flakeModules/dendritic/flake-module.nix
@@ -1,39 +1,172 @@
-{inputs, ...}: {
-  flake-file.inputs.dendritic = {
-    url = "github:krad246/nix-systems/dendritic";
-
-    inputs = {
-      agenix.follows = "agenix";
-      agenix-shell.follows = "agenix-shell";
-      disko.follows = "disko";
-      flake-compat.follows = "flake-compat";
-      flake-file.follows = "flake-file";
-      flake-parts.follows = "flake-parts";
-      flake-root.follows = "flake-root";
-      home-manager.follows = "home-manager";
-      impermanence.follows = "impermanence";
-      just-flake.follows = "just-flake";
-      nix-darwin.follows = "darwin";
-      nix-homebrew.follows = "nix-homebrew";
-      nixos-wsl.follows = "nixos-wsl";
-      nixpkgs.follows = "nixpkgs";
-      nixpkgs-lib.follows = "nixpkgs";
-      nixpkgs-unstable.follows = "nixpkgs-unstable";
-      pre-commit-hooks-nix.follows = "pre-commit-hooks-nix";
-      systems.follows = "systems";
-      treefmt-nix.follows = "treefmt-nix";
-    };
+{
+  config,
+  inputs,
+  lib,
+  ...
+}: {
+  options.flake.homeConfigurations = lib.mkOption {
+    type = lib.types.lazyAttrsOf lib.types.raw;
+    default = {};
+    description = "Mergeable registry of standalone Home Manager configurations.";
   };
 
-  # Stable migration seam. Consumers use this namespace while its values are
-  # progressively replaced with modules materialized in the current tree.
-  flake.dendritic = {
-    inherit
-      (inputs.dendritic)
-      darwinModules
-      homeModules
-      modules
-      nixosModules
-      ;
+  config = {
+    flake-file.inputs.dendritic = {
+      url = "github:krad246/nix-systems/dendritic";
+
+      inputs = {
+        agenix.follows = "agenix";
+        agenix-shell.follows = "agenix-shell";
+        disko.follows = "disko";
+        flake-compat.follows = "flake-compat";
+        flake-file.follows = "flake-file";
+        flake-parts.follows = "flake-parts";
+        flake-root.follows = "flake-root";
+        home-manager.follows = "home-manager";
+        impermanence.follows = "impermanence";
+        just-flake.follows = "just-flake";
+        nix-darwin.follows = "darwin";
+        nix-homebrew.follows = "nix-homebrew";
+        nixos-wsl.follows = "nixos-wsl";
+        nixpkgs.follows = "nixpkgs";
+        nixpkgs-lib.follows = "nixpkgs";
+        nixpkgs-unstable.follows = "nixpkgs-unstable";
+        pre-commit-hooks-nix.follows = "pre-commit-hooks-nix";
+        systems.follows = "systems";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
+    # Stable migration seam. Consumers use this namespace while its values are
+    # progressively replaced with modules materialized in the current tree.
+    flake.dendritic = rec {
+      inherit (inputs.dendritic) darwinModules nixosModules;
+
+      modules =
+        inputs.dendritic.modules
+        // {
+          homeManager =
+            inputs.dendritic.modules.homeManager
+            // rec {
+              base = {
+                lib,
+                pkgs,
+                ...
+              }: {
+                imports = [
+                  inputs.dendritic.homeModules.home-manager
+                  inputs.dendritic.homeModules.identity
+                ];
+
+                config = lib.mkMerge [
+                  {
+                    home.preferXdgDirectories = true;
+                    manual = {
+                      html.enable = false;
+                      json.enable = true;
+                    };
+                    news.display = "silent";
+                    xdg.enable = true;
+                  }
+                  (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
+                    targets.genericLinux = {
+                      enable = true;
+                      gpu.enable = lib.mkDefault false;
+                    };
+
+                    systemd.user.startServices = "sd-switch";
+                  })
+                ];
+              };
+
+              standalone = {
+                config,
+                pkgs,
+                ...
+              }: {
+                imports = [base];
+
+                home = {
+                  username = lib.mkDefault config.identity.person.username;
+                  homeDirectory = lib.mkDefault (
+                    if pkgs.stdenv.hostPlatform.isDarwin
+                    then "/Users/${config.identity.person.username}"
+                    else "/home/${config.identity.person.username}"
+                  );
+                };
+
+                nix.package = lib.mkDefault pkgs.nix;
+              };
+            };
+        };
+
+      homeModules = modules.homeManager;
+
+      homeConfigurations = let
+        inherit (config.flake.dendritic.homeModules) standalone;
+      in {
+        base-aarch64-darwin = inputs.home-manager.lib.homeManagerConfiguration {
+          pkgs = inputs.nixpkgs.legacyPackages.aarch64-darwin;
+          modules = [standalone];
+        };
+
+        base-x86_64-linux = inputs.home-manager.lib.homeManagerConfiguration {
+          pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
+          modules = [standalone];
+        };
+      };
+    };
+
+    flake.homeConfigurations = lib.mkIf (!lib.inPureEvalMode) {
+      base = inputs.home-manager.lib.homeManagerConfiguration {
+        pkgs = import inputs.nixpkgs {
+          system = builtins.currentSystem;
+          config.allowUnfree = true;
+        };
+        modules = let inherit (config.flake.dendritic.homeModules) standalone; in [standalone];
+      };
+    };
+
+    perSystem = {system, ...}:
+      lib.mkMerge [
+        (lib.mkIf (system == "aarch64-darwin") {
+          checks.dendritic-hm-base = let
+            configuration = config.flake.dendritic.homeConfigurations.base-aarch64-darwin;
+            cfg = configuration.config;
+          in
+            assert cfg.home.username == "krad246";
+            assert cfg.home.homeDirectory == "/Users/krad246";
+            assert cfg.identity.person
+            == {
+              email = "krad246@gmail.com";
+              name = "Keerthi Radhakrishnan";
+              username = "krad246";
+            };
+            assert cfg.xdg.enable;
+            assert cfg.manual.json.enable;
+            assert !cfg.manual.html.enable;
+            assert cfg.programs.home-manager.enable;
+            assert !cfg.programs.bash.enable;
+            assert !cfg.programs.bat.enable;
+            assert !cfg.programs.fzf.enable;
+            assert !cfg.programs.git.enable;
+            assert !cfg.programs.helix.enable;
+            assert !cfg.programs.kitty.enable;
+            assert !cfg.programs.rbw.enable;
+              configuration.activationPackage;
+        })
+        (lib.mkIf (system == "x86_64-linux") {
+          checks.dendritic-hm-base = let
+            configuration = config.flake.dendritic.homeConfigurations.base-x86_64-linux;
+            cfg = configuration.config;
+          in
+            assert cfg.home.username == "krad246";
+            assert cfg.home.homeDirectory == "/home/krad246";
+            assert cfg.targets.genericLinux.enable;
+            assert !cfg.targets.genericLinux.gpu.enable;
+            assert cfg.systemd.user.startServices;
+              configuration.activationPackage;
+        })
+      ];
   };
 }

--- a/flakeModules/devShell/flake-module.nix
+++ b/flakeModules/devShell/flake-module.nix
@@ -62,9 +62,9 @@ in {
             makefile = self'.packages."makefile-${arch}-linux";
             devcontainer-json = self'.packages."devcontainer-json-${arch}-linux";
           in ''
-            FLAKE_ROOT="$(${lib.meta.getExe config.flake-root.package})"
-            ${lib.meta.getExe' pkgs.coreutils "ln"} -snvrf ${makefile} $FLAKE_ROOT/Makefile
-            ${lib.meta.getExe' pkgs.coreutils "ln"} -snvrf ${devcontainer-json} $FLAKE_ROOT/.devcontainer.json
+            root="$(${lib.meta.getExe config.flake-root.package})"
+            ${lib.meta.getExe' pkgs.coreutils "ln"} -snvrf ${makefile} "$root/Makefile"
+            ${lib.meta.getExe' pkgs.coreutils "ln"} -snvrf ${devcontainer-json} "$root/.devcontainer.json"
           '';
         };
       })
@@ -89,8 +89,8 @@ in {
 
           shellHook = ''
             source ${lib.meta.getExe config.agenix-shell.installationScript}
-            FLAKE_ROOT="$(${lib.meta.getExe config.flake-root.package})"
-            eval "$(${lib.meta.getExe pkgs.lorri} direnv --context $FLAKE_ROOT --flake $FLAKE_ROOT)"
+            root="$(${lib.meta.getExe config.flake-root.package})"
+            eval "$(${lib.meta.getExe pkgs.lorri} direnv --context "$root" --flake "$root")"
           '';
         };
 

--- a/justfile
+++ b/justfile
@@ -1,10 +1,9 @@
 #!/usr/bin/env just --justfile
 
-flake := env_var_or_default('FLAKE_ROOT', justfile_directory())
+flake := justfile_directory()
 hostname := env_var_or_default('HOSTNAME', shell('hostname'))
 tmpdir := shell('mktemp -d')
 whoami := shell('whoami')
-direnv_dir := (flake / ".direnv")
 
 # List all of the recipes and groups.
 [group('summary')]

--- a/setup.sh
+++ b/setup.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-SCRIPT="$(realpath "$0")"
-SCRIPTPATH="$(dirname "$SCRIPT")"
+root="$(cd "$(dirname "$0")" && pwd -P)"
 
 # shellcheck source=sh/install-nix.sh
-source "$SCRIPTPATH/sh/install-nix.sh"
+source "$root/sh/install-nix.sh"
 
 # shellcheck source=sh/bootstrap.sh
-exec "$SCRIPTPATH/sh/bootstrap.sh" "$@"
+exec "$root/sh/bootstrap.sh" "$@"

--- a/sh/bootstrap.sh
+++ b/sh/bootstrap.sh
@@ -4,28 +4,28 @@ set -euo pipefail
 root="$(cd "$(dirname "$0")/.." && pwd -P)"
 
 command -v git >/dev/null 2>&1 || {
-  printf 'bootstrap: git is required before entering the Nix bootstrap app\n' >&2
-  exit 1
+	printf 'bootstrap: git is required before entering the Nix bootstrap app\n' >&2
+	exit 1
 }
 command -v nix >/dev/null 2>&1 || {
-  printf 'bootstrap: nix is required; run setup.sh instead\n' >&2
-  exit 1
+	printf 'bootstrap: nix is required; run setup.sh instead\n' >&2
+	exit 1
 }
 
 safe=false
 while IFS= read -r directory; do
-  [[ $directory == "$root" ]] && safe=true
+	[[ $directory == "$root" ]] && safe=true
 done < <(git config --global --get-all safe.directory || true)
 if [[ $safe == false ]]; then
-  if [[ ! -t 0 ]]; then
-    printf 'bootstrap: refusing to change global Git config without interactive approval\n' >&2
-    exit 1
-  fi
-  read -r -p "Trust this checkout in global Git config? [y/N] " reply
-  [[ $reply == [yY] ]] || exit 1
-  git config --global --add safe.directory "$root"
+	if [[ ! -t 0 ]]; then
+		printf 'bootstrap: refusing to change global Git config without interactive approval\n' >&2
+		exit 1
+	fi
+	read -r -p "Trust this checkout in global Git config? [y/N] " reply
+	[[ $reply == [yY] ]] || exit 1
+	git config --global --add safe.directory "$root"
 fi
 
 exec nix \
-  --option experimental-features 'nix-command flakes' \
-  run "$root#bootstrap" -- "$root" "$@"
+	--option experimental-features 'nix-command flakes' \
+	run "$root#bootstrap" -- "$root" "$@"

--- a/sh/bootstrap.sh
+++ b/sh/bootstrap.sh
@@ -17,6 +17,12 @@ while IFS= read -r directory; do
   [[ $directory == "$root" ]] && safe=true
 done < <(git config --global --get-all safe.directory || true)
 if [[ $safe == false ]]; then
+  if [[ ! -t 0 ]]; then
+    printf 'bootstrap: refusing to change global Git config without interactive approval\n' >&2
+    exit 1
+  fi
+  read -r -p "Trust this checkout in global Git config? [y/N] " reply
+  [[ $reply == [yY] ]] || exit 1
   git config --global --add safe.directory "$root"
 fi
 

--- a/sh/bootstrap.sh
+++ b/sh/bootstrap.sh
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-SCRIPT="$(realpath "$0")"
-SCRIPTPATH="$(dirname "$SCRIPT")"
+root="$(cd "$(dirname "$0")/.." && pwd -P)"
 
-allow() {
-  git config --global --add safe.directory "$(realpath "$1")"
-  git config --global --add safe.directory "$(realpath "$1/.git")"
+command -v git >/dev/null 2>&1 || {
+  printf 'bootstrap: git is required before entering the Nix bootstrap app\n' >&2
+  exit 1
+}
+command -v nix >/dev/null 2>&1 || {
+  printf 'bootstrap: nix is required; run setup.sh instead\n' >&2
+  exit 1
 }
 
-allow "$SCRIPTPATH/.."
+safe=false
+while IFS= read -r directory; do
+  [[ $directory == "$root" ]] && safe=true
+done < <(git config --global --get-all safe.directory || true)
+if [[ $safe == false ]]; then
+  git config --global --add safe.directory "$root"
+fi
 
 exec nix \
   --option experimental-features 'nix-command flakes' \
-  run "$SCRIPTPATH/../#bootstrap" -- "$@"
+  run "$root#bootstrap" -- "$root" "$@"

--- a/sh/install-nix.sh
+++ b/sh/install-nix.sh
@@ -1,12 +1,22 @@
 #!/usr/bin/env bash
 
-if ! command -v nix; then
-  sh <(curl -L https://nixos.org/nix/install) \
+if ! command -v nix >/dev/null 2>&1; then
+  command -v curl >/dev/null 2>&1 || {
+    printf 'setup: curl is required to install Nix\n' >&2
+    return 1
+  }
+
+  sh <(curl --fail --location --show-error https://nixos.org/nix/install) \
     --daemon --yes \
-    --nix-extra-conf-file <(echo 'experimental-features = nix-command flakes')
+    --nix-extra-conf-file <(printf '%s\n' 'experimental-features = nix-command flakes')
 
   if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
     # shellcheck source=/dev/null
     . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
   fi
 fi
+
+command -v nix >/dev/null 2>&1 || {
+  printf 'setup: Nix was installed but is unavailable in this shell\n' >&2
+  return 1
+}

--- a/sh/install-nix.sh
+++ b/sh/install-nix.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
 
 if ! command -v nix >/dev/null 2>&1; then
-  command -v curl >/dev/null 2>&1 || {
-    printf 'setup: curl is required to install Nix\n' >&2
-    return 1
-  }
+	command -v curl >/dev/null 2>&1 || {
+		printf 'setup: curl is required to install Nix\n' >&2
+		return 1
+	}
 
-  sh <(curl --fail --location --show-error https://nixos.org/nix/install) \
-    --daemon --yes \
-    --nix-extra-conf-file <(printf '%s\n' 'experimental-features = nix-command flakes')
+	sh <(curl --fail --location --show-error https://nixos.org/nix/install) \
+		--daemon --yes \
+		--nix-extra-conf-file <(printf '%s\n' 'experimental-features = nix-command flakes')
 
-  if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
-    # shellcheck source=/dev/null
-    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
-  fi
+	if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
+		# shellcheck source=/dev/null
+		. '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+	fi
 fi
 
 command -v nix >/dev/null 2>&1 || {
-  printf 'setup: Nix was installed but is unavailable in this shell\n' >&2
-  return 1
+	printf 'setup: Nix was installed but is unavailable in this shell\n' >&2
+	return 1
 }


### PR DESCRIPTION
## What changed

- Adds the cross-platform Dendritic Home Manager base and exact input-registry landing cone
- Adds proof checks for the integrated and standalone foundation
- Hardens the clone-to-devshell bootstrap path and agent checkpoint app
- Pins the approved Dendritic freeze point at `06cece4c`
- Records explicit owner decision gates for legacy Generic Linux behavior

## Scope

This lands the foundation only. It does not reproduce the legacy `generic-linux` desktop payload or delete those files. Linux target/service switching and XDG are already captured. VS Code and VS Code Server are explicitly deferred and are not parity gates. Flatpak, Dconf/GNOME semantics, desktop specialization, terminal backends, and launcher policy require explicit retain/redesign/drop decisions before migration.

## Validation

- `nix build .#checks.aarch64-darwin.dendritic-hm-base .#checks.aarch64-darwin.check-flake-file .#checks.aarch64-darwin.pre-commit`
- Pinned devshell pre-commit hooks pass
- Context bundle checkpoint and local cache verification pass

The broad `nix flake check --no-build` remains blocked by the pre-existing Fortress `networking.wireless.enable` conflict, outside this PR scope.