### PR TITLE
Allow direct Git clean commands

### DIFF
--- a/modules/shell/programs/git/config.nix
+++ b/modules/shell/programs/git/config.nix
@@ -9,6 +9,8 @@
         apply.whitespace = "fix";
         branch.sort = "-committerdate";
 
+        clean.requireForce = false;
+
         core = {
           eol = "lf";
           autocrlf = "input";


### PR DESCRIPTION
## What changed

Set the managed Git configuration `clean.requireForce` to `false`.

## Why

The Dendritic Git module previously inherited Git’s default requirement for an extra `-f`, making explicit commands such as `git clean -fd` and `git clean -fdx` require redundant force spelling. The command remains explicitly destructive, but now behaves as configured by the maintainer.

## Validation

- Evaluated `darwinConfigurations.nixbook-pro.config.home-manager.users.krad246.programs.git.settings.clean.requireForce` to `false`
- Evaluated the Darwin system derivation
- Ran the configured pre-commit and pre-push hooks successfully