### PR TITLE
Expose interactive system profiles

### DIFF
--- a/modules/profiles/standalone.nix
+++ b/modules/profiles/standalone.nix
@@ -31,6 +31,7 @@
         standalone
         desktop
         dev
+        interactive
         secrets
       ];
 

--- a/modules/profiles/workstation.nix
+++ b/modules/profiles/workstation.nix
@@ -9,6 +9,7 @@
         base
         desktop
         dev
+        interactive
         secrets
       ];
 
@@ -24,6 +25,7 @@
         base
         desktop
         dev
+        interactive
         secrets
       ];
     };
@@ -33,6 +35,7 @@
         base
         desktop
         dev
+        interactive
         secrets
       ];
 

--- a/modules/shell/interactive.nix
+++ b/modules/shell/interactive.nix
@@ -1,76 +1,100 @@
-{lib, ...}: {
-  flake.modules.homeManager.shell = {
-    config,
-    pkgs,
-    ...
-  }: let
-    cfg = config.shell.profiles.interactive;
-  in {
-    options.shell.profiles.interactive.enable =
-      lib.options.mkEnableOption "Whether this to turn on interactive tools and integrations for the CLI."
-      // {
-        default = true;
-      };
-
-    config = lib.modules.mkIf cfg.enable {
-      shell = {
-        backends = {
-          bash.enable = true;
-          nushell.enable = lib.modules.mkDefault false;
+{
+  self,
+  lib,
+  ...
+}: {
+  flake.modules = {
+    homeManager.shell = {
+      config,
+      pkgs,
+      ...
+    }: let
+      cfg = config.shell.profiles.interactive;
+    in {
+      options.shell.profiles.interactive.enable =
+        lib.options.mkEnableOption "interactive tools and integrations for the CLI"
+        // {
+          default = true;
         };
-        integrations = {
-          bat.enable = true;
-          fzf.enable = lib.modules.mkDefault config.picker.backends.fzf.enable;
-          lsd.enable = true;
-          starship.enable = true;
-          yazi.enable = true;
-          zoxide.enable = true;
-        };
-        programs = {
-          bat.enable = true;
-          bottom.enable = true;
-          diff.enable = true;
-          fd.enable = true;
-          lsd.enable = true;
-          man.enable = true;
-          pager.enable = true;
-          ripgrep.enable = true;
-          starship.enable = true;
-          yazi.enable = true;
-          zoxide.enable = true;
-        };
-      };
 
-      picker.backends.fzf.integrations = {
-        bat.enable = lib.modules.mkDefault true;
-        fd.enable = lib.modules.mkDefault true;
-      };
+      config = lib.modules.mkIf cfg.enable {
+        shell = {
+          backends = {
+            bash.enable = true;
+            nushell.enable = lib.modules.mkDefault false;
+          };
+          integrations = {
+            bat.enable = true;
+            fzf.enable = lib.modules.mkDefault config.picker.backends.fzf.enable;
+            lsd.enable = true;
+            starship.enable = true;
+            yazi.enable = true;
+            zoxide.enable = true;
+          };
+          programs = {
+            bat.enable = true;
+            bottom.enable = true;
+            diff.enable = true;
+            fd.enable = true;
+            lsd.enable = true;
+            man.enable = true;
+            pager.enable = true;
+            ripgrep.enable = true;
+            starship.enable = true;
+            yazi.enable = true;
+            zoxide.enable = true;
+          };
+        };
 
-      home.packages = with pkgs; ([
-          coreutils
-          curl
-          duf
-          dust
-          file
-          gnutar
-          jq
-          procps
-          # safe-rm # FIXME: not useful unless aliasing rm
-          sd
-          tldr
-          tree
-          which
-          unzip
-          zip
-        ]
-        ++ lib.lists.optionals pkgs.stdenv.hostPlatform.isLinux [
-          bashmount
-          psmisc
-          strace
-        ]
-        ++ lib.lists.optionals pkgs.stdenv.hostPlatform.isDarwin [
-          m-cli
-        ]);
+        picker.backends.fzf.integrations = {
+          bat.enable = lib.modules.mkDefault true;
+          fd.enable = lib.modules.mkDefault true;
+        };
+
+        home.packages = with pkgs; ([
+            coreutils
+            curl
+            duf
+            dust
+            file
+            gnutar
+            jq
+            procps
+            # safe-rm # FIXME: not useful unless aliasing rm
+            sd
+            tldr
+            tree
+            which
+            unzip
+            zip
+          ]
+          ++ lib.lists.optionals pkgs.stdenv.hostPlatform.isLinux [
+            bashmount
+            psmisc
+            strace
+          ]
+          ++ lib.lists.optionals pkgs.stdenv.hostPlatform.isDarwin [
+            m-cli
+          ]);
+      };
+    };
+
+    homeManager.interactive = {
+      imports = [self.modules.homeManager.shell];
+
+      shell.profiles.interactive.enable = true;
+    };
+
+    nixos.interactive = {config, ...}: {
+      home-manager.users.${config.owner.username}.imports = [
+        self.modules.homeManager.interactive
+      ];
+    };
+
+    darwin.interactive = {config, ...}: {
+      home-manager.users.${config.owner.username}.imports = [
+        self.modules.homeManager.interactive
+      ];
     };
   };
 }


### PR DESCRIPTION
## What changed

- Adds `homeManager.interactive` as the explicit HM experience preset over the reusable shell capability
- Adds thin `nixos.interactive` and `darwin.interactive` adapters that import that HM preset for the system owner
- Makes workstation and standalone-workstation compositions select interactive explicitly
- Preserves the existing shell option default for compatibility while making consumer intent durable

## Why

System configurations should compose semantic profiles at their own module level while standalone Home Manager configurations retain equivalent composition at the HM level. This provides one HM implementation with explicit adapters, without `specialArgs` or direct system-level writes into shell implementation options.

## Validation

- Alejandra and diff checks pass
- `homeManager.interactive`, `nixos.interactive`, and `darwin.interactive` all evaluate as registered modules
- Full configured pre-commit and pre-push hooks pass