### PR TITLE
Avoid duplicate interactive shell imports

### DIFF
--- a/modules/shell/interactive.nix
+++ b/modules/shell/interactive.nix
@@ -80,8 +80,6 @@
     };
 
     homeManager.interactive = {
-      imports = [self.modules.homeManager.shell];
-
       shell.profiles.interactive.enable = true;
     };
 


### PR DESCRIPTION
## What changed

Remove the redundant `homeManager.shell` import from `homeManager.interactive`.

## Why

`interactive` is a profile selector, analogous to `dev`: callers explicitly compose it with `base`, which already establishes the inert shell capability/interface graph. Re-importing `shell` through both paths violates Nix module one-definition behavior and duplicates option declarations in integrated Home Manager consumers.

## Validation

- Full configured pre-commit and pre-push hooks pass
- The correction is rebased on the merged interactive-profile commit
- The main-owned `nixos.headless + nixos.interactive` QEMU proof exposed and reproduces the duplicate-declaration failure before this fix