### PR TITLE
Add headless interactive VM proof

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -323,11 +323,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786598930,
-        "narHash": "sha256-aFRP9iz1tOlG0f78k7SmhgAIjIZMxR4zO0e/dsizu1w=",
+        "lastModified": 1786602120,
+        "narHash": "sha256-39Zp/Vs5ej4d42iYIYc32xd3Um/2KbHC+tJYLkcWjlw=",
         "owner": "krad246",
         "repo": "nix-systems",
-        "rev": "06cece4c1a90af8c79da1b53d3a535dbefaff5ef",
+        "rev": "945113a542de8af345d1029cd6f8e926ff6e730f",
         "type": "github"
       },
       "original": {

--- a/flakeModules/dendritic/flake-module.nix
+++ b/flakeModules/dendritic/flake-module.nix
@@ -124,7 +124,9 @@
           pkgs = withSystem builtins.currentSystem ({pkgs, ...}: pkgs);
           modules = let
             inherit (config.flake.dendritic.homeModules) standalone;
-          in [standalone];
+          in [
+            standalone
+          ];
         };
       };
 

--- a/flakeModules/dendritic/flake-module.nix
+++ b/flakeModules/dendritic/flake-module.nix
@@ -2,6 +2,7 @@
   config,
   inputs,
   lib,
+  withSystem,
   ...
 }: {
   options.flake.homeConfigurations = lib.mkOption {
@@ -120,11 +121,10 @@
     flake = {
       homeConfigurations = lib.mkIf (!lib.inPureEvalMode) {
         base = inputs.home-manager.lib.homeManagerConfiguration {
-          pkgs = import inputs.nixpkgs {
-            system = builtins.currentSystem;
-            config.allowUnfree = true;
-          };
-          modules = let inherit (config.flake.dendritic.homeModules) standalone; in [standalone];
+          pkgs = withSystem builtins.currentSystem ({pkgs, ...}: pkgs);
+          modules = let
+            inherit (config.flake.dendritic.homeModules) standalone;
+          in [standalone];
         };
       };
 
@@ -138,19 +138,9 @@
             lib,
             ...
           }: {
-            image.modules.vm = {
-              config,
-              modulesPath,
-              ...
-            }: {
-              imports = ["${modulesPath}/virtualisation/qemu-vm.nix"];
-
-              system.build.image = config.system.build.vm;
-            };
-
-            image.modules.vm-nogui = {
-              imports = [config.image.modules.vm];
-              virtualisation.graphics = false;
+            image.modules.vm = import ./image-modules/vm.nix;
+            image.modules.vm-nogui = import ./image-modules/vm-nogui.nix {
+              vm = config.image.modules.vm;
             };
 
             home-manager.users.krad246 = {
@@ -193,9 +183,6 @@
               configuration.activationPackage;
         })
         (lib.mkIf (system == "x86_64-linux") {
-          packages.generic-headless-interactive-vm =
-            config.flake.nixosConfigurations.generic-headless-interactive.config.system.build.images.vm-nogui;
-
           checks.dendritic-hm-base = let
             configuration = config.flake.dendritic.homeConfigurations.base-x86_64-linux;
             cfg = configuration.config;

--- a/flakeModules/dendritic/flake-module.nix
+++ b/flakeModules/dendritic/flake-module.nix
@@ -117,13 +117,50 @@
       };
     };
 
-    flake.homeConfigurations = lib.mkIf (!lib.inPureEvalMode) {
-      base = inputs.home-manager.lib.homeManagerConfiguration {
-        pkgs = import inputs.nixpkgs {
-          system = builtins.currentSystem;
-          config.allowUnfree = true;
+    flake = {
+      homeConfigurations = lib.mkIf (!lib.inPureEvalMode) {
+        base = inputs.home-manager.lib.homeManagerConfiguration {
+          pkgs = import inputs.nixpkgs {
+            system = builtins.currentSystem;
+            config.allowUnfree = true;
+          };
+          modules = let inherit (config.flake.dendritic.homeModules) standalone; in [standalone];
         };
-        modules = let inherit (config.flake.dendritic.homeModules) standalone; in [standalone];
+      };
+
+      nixosConfigurations.generic-headless-interactive = inputs.nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          config.flake.dendritic.modules.nixos.headless
+          config.flake.dendritic.modules.nixos.interactive
+          ({
+            config,
+            lib,
+            ...
+          }: {
+            image.modules.vm = {
+              config,
+              modulesPath,
+              ...
+            }: {
+              imports = ["${modulesPath}/virtualisation/qemu-vm.nix"];
+
+              system.build.image = config.system.build.vm;
+            };
+
+            image.modules.vm-nogui = {
+              imports = [config.image.modules.vm];
+              virtualisation.graphics = false;
+            };
+
+            home-manager.users.krad246 = {
+              home.stateVersion = lib.mkForce "26.05";
+            };
+
+            networking.hostName = "generic-headless-interactive";
+            system.stateVersion = lib.mkForce "25.11";
+          })
+        ];
       };
     };
 
@@ -156,6 +193,9 @@
               configuration.activationPackage;
         })
         (lib.mkIf (system == "x86_64-linux") {
+          packages.generic-headless-interactive-vm =
+            config.flake.nixosConfigurations.generic-headless-interactive.config.system.build.images.vm-nogui;
+
           checks.dendritic-hm-base = let
             configuration = config.flake.dendritic.homeConfigurations.base-x86_64-linux;
             cfg = configuration.config;
@@ -166,6 +206,15 @@
             assert !cfg.targets.genericLinux.gpu.enable;
             assert cfg.systemd.user.startServices;
               configuration.activationPackage;
+
+          checks.generic-headless-interactive = let
+            configuration = config.flake.nixosConfigurations.generic-headless-interactive;
+            image = configuration.config.system.build.images.vm-nogui;
+            cfg = image.passthru.config;
+          in
+            assert !cfg.virtualisation.graphics;
+            assert !cfg.services.xserver.enable;
+            assert cfg.home-manager.users.${cfg.owner.username}.shell.profiles.interactive.enable; image;
         })
       ];
   };

--- a/flakeModules/dendritic/image-modules/vm-nogui.nix
+++ b/flakeModules/dendritic/image-modules/vm-nogui.nix
@@ -1,3 +1,6 @@
+# Like `importApply`: the outer argument closes over the registered VM module,
+# while this function returns the deferred NixOS module evaluated later.
+# TODO: investigate an import-tree closure bridge built on `importApply`.
 {vm}: {
   imports = [vm];
 

--- a/flakeModules/dendritic/image-modules/vm-nogui.nix
+++ b/flakeModules/dendritic/image-modules/vm-nogui.nix
@@ -1,0 +1,5 @@
+{vm}: {
+  imports = [vm];
+
+  virtualisation.graphics = false;
+}

--- a/flakeModules/dendritic/image-modules/vm.nix
+++ b/flakeModules/dendritic/image-modules/vm.nix
@@ -1,0 +1,9 @@
+{
+  config,
+  modulesPath,
+  ...
+}: {
+  imports = ["${modulesPath}/virtualisation/qemu-vm.nix"];
+
+  system.build.image = config.system.build.vm;
+}


### PR DESCRIPTION
## What changed

- update the Dendritic pin to the landed interactive-profile composition
- compose a `generic-headless-interactive` NixOS proof from the Dendritic `headless` and `interactive` modules
- register a reusable `vm` image deferred module and derive `vm-nogui` by importing the outer registry entry and disabling graphics
- expose and check the resulting no-GUI VM image

## Why

This proves the same semantic profile composition at the system and Home Manager layers while keeping target image selection orthogonal. The no-GUI variant follows upstream `qemu-vm.nix`: it reuses `system.build.vm`, sets `virtualisation.graphics = false`, and lets the upstream module provide serial-console behavior.

## Validation

- `nix build .#checks.x86_64-linux.generic-headless-interactive .#checks.x86_64-linux.dendritic-hm-base`
- `nix eval` confirms `virtualisation.graphics = false`
- `nix eval` confirms consoles `[ "tty0" "ttyS0,115200n8" ]`
- full repository `pre-commit run --all-files`
- pre-push `check-flake` and `realize-dendritic-hm-base`
