### PR TITLE
Expose headless Home Manager profile

### DIFF
--- a/modules/profiles/headless.nix
+++ b/modules/profiles/headless.nix
@@ -1,8 +1,14 @@
 {self, ...}: {
-  flake.modules.nixos.headless = {
-    imports = with self.modules.nixos; [
-      base
-      terminfo
-    ];
+  flake.modules = {
+    homeManager.headless = {
+      imports = [self.modules.homeManager.base];
+    };
+
+    nixos.headless = {
+      imports = with self.modules.nixos; [
+        base
+        terminfo
+      ];
+    };
   };
 }


### PR DESCRIPTION
## What changed

- expose `homeManager.headless` beside the existing NixOS `headless` profile
- keep it as the inert Home Manager base composition only

## Why

This gives configuration sites symmetric Home Manager and NixOS profile vocabulary without introducing a combined `headless-interactive` tier. Concrete configurations explicitly compose `headless` with `interactive` when that experience is required.

## Validation

- evaluated `modules.homeManager.headless`
- built `checks.aarch64-darwin.pre-commit`
- repository commit and push hooks passed

`nix flake check --no-build` still reaches the pre-existing `miniboi` root-filesystem assertion; this module does not alter provisioning.
