### PR TITLE
Materialize miniboi deployment root

### DIFF
--- a/modules/hardware/boot/loader/backends/grub/mode.nix
+++ b/modules/hardware/boot/loader/backends/grub/mode.nix
@@ -10,17 +10,13 @@
     };
 
     config = lib.modules.mkIf cfg.enable {
-      boot.loader.grub = lib.modules.mkMerge [
-        # (
-        {device = "/dev/vda";}
-        (lib.modules.mkIf (cfg.mode == "efi") {
-          device = "nodev";
-          efiSupport = true;
+      boot.loader.grub = lib.modules.mkIf (cfg.mode == "efi") {
+        device = "nodev";
+        efiSupport = true;
 
-          # TODO: use this only in deployments with disko.
-          # efiInstallAsRemovable = lib.modules.mkDefault false;
-        })
-      ];
+        # TODO: use this only in deployments with disko.
+        # efiInstallAsRemovable = lib.modules.mkDefault false;
+      };
     };
   };
 }

--- a/modules/hosts/miniboi/configuration.nix
+++ b/modules/hosts/miniboi/configuration.nix
@@ -34,6 +34,8 @@
       }
       {
         imports = [self.diskoConfigurations.simple];
+
+        disko.enableConfig = true;
       }
 
       {


### PR DESCRIPTION
## What changed

- enable Disko's NixOS configuration projection at the concrete `miniboi` deployment boundary
- remove the GRUB backend's hardcoded `/dev/vda`; Disko now supplies the declarative boot device

## Why

`miniboi` already declares a complete disk topology, but `disko.enableConfig = false` prevented that topology from materializing the root filesystem in the named NixOS configuration. The GRUB adapter then duplicated Disko's device through the legacy singular `boot.loader.grub.device` option.

The resulting configuration preserves Disko's two-phase contract: the named system has a pure, switchable root topology and placeholder device, while `disko-install --disk` can late-bind the physical device through its temporary `extendModules` projection.

## Validation

- `/` evaluates to `/dev/disk/by-partlabel/disk-main-root`
- declarative disk remains `/dev/vda`
- GRUB device list evaluates once as `[ "/dev/vda" ]`
- `system.build.toplevel.drvPath` evaluates
- `nix flake check --no-build` passes all outputs
- commit and push hooks pass

## Stack

Depends on #441 and targets its branch. Merge #441 first, then retarget this PR to `dendritic`.
