### PR TITLE
Publish coherent flake library

### DIFF
--- a/modules/flake/lib.nix
+++ b/modules/flake/lib.nix
@@ -1,0 +1,3 @@
+{inputs, ...}: {
+  flake.lib = inputs.nixpkgs.lib;
+}

--- a/modules/home-manager/enable.nix
+++ b/modules/home-manager/enable.nix
@@ -32,8 +32,8 @@
       ];
     };
 
-    homeManager.home-manager = {lib, ...}: {
-      home.stateVersion = lib.trivial.release;
+    homeManager.home-manager = {
+      home.stateVersion = self.lib.trivial.release;
       programs.home-manager.enable = true;
     };
   };

--- a/modules/profiles/base.nix
+++ b/modules/profiles/base.nix
@@ -1,8 +1,6 @@
-{
-  self,
-  lib,
-  ...
-}: {
+{self, ...}: let
+  inherit (self) lib;
+in {
   flake.modules = {
     homeManager.base = {pkgs, ...}: {
       imports = with self.modules.homeManager; [


### PR DESCRIPTION
## Summary

- publish `self.lib` from the sole followed Nixpkgs input
- use that coherent flake library for HM and NixOS state-version defaults
- prevent published inner modules from accidentally capturing flake-parts module arguments

## Why

The bridge exposed a `26.11`/`26.05` Home Manager state-version mismatch because registry modules captured whichever `lib` evaluated the flake-level declaration. A first-class `self.lib` gives the flake and its published modules one coherent library fixed point while leaving inner extended libraries explicit.

## Validation

- `self.lib.trivial.release == inputs.nixpkgs.lib.trivial.release`
- nix-darwin-integrated HM state version equals `self.lib.trivial.release`
- NixOS-integrated HM and NixOS system state versions equal `self.lib.trivial.release`
- formatting, nil, statix, deadnix, treefmt, and pre-push hooks pass