### PR TITLE
Prove coherent flake library consumers

### DIFF
--- a/modules/flake/lib.nix
+++ b/modules/flake/lib.nix
@@ -1,3 +1,30 @@
-{inputs, ...}: {
+{
+  inputs,
+  self,
+  ...
+}: {
   flake.lib = inputs.nixpkgs.lib;
+
+  perSystem = {system, ...}:
+    self.lib.mkMerge [
+      (self.lib.mkIf (system == "aarch64-darwin") {
+        checks.flake-lib-nixbook-pro = let
+          cfg = self.darwinConfigurations.nixbook-pro.config;
+          home = cfg.home-manager.users.${cfg.owner.username};
+        in
+          assert self.lib.trivial.release == inputs.nixpkgs.lib.trivial.release;
+          assert home.home.stateVersion == self.lib.trivial.release;
+            home.home.activationPackage;
+      })
+      (self.lib.mkIf (system == "aarch64-linux") {
+        checks.flake-lib-miniboi = let
+          cfg = self.nixosConfigurations.miniboi.config;
+          home = cfg.home-manager.users.${cfg.owner.username};
+        in
+          assert self.lib.trivial.release == inputs.nixpkgs.lib.trivial.release;
+          assert cfg.system.stateVersion == self.lib.trivial.release;
+          assert home.home.stateVersion == self.lib.trivial.release;
+            cfg.system.build.toplevel;
+      })
+    ];
 }

--- a/modules/shell/dev.nix
+++ b/modules/shell/dev.nix
@@ -58,7 +58,7 @@
           nix-du
           nix-fast-build
           nix-output-monitor
-          nodePackages.undollar
+          undollar
           # safe-rm
         ];
 


### PR DESCRIPTION
## Summary

- assert `self.lib` has the same release provenance as the sole Nixpkgs input
- prove the real nixbook-pro integrated HM consumer uses that release
- prove miniboi system and integrated HM state versions use that release

## Validation

Both new check derivations evaluate, and the full formatting/static hook suite plus pre-push hooks pass.

## Review order

This follows merged #443 and should merge before the combined main cleanup PR advances the frozen bridge pin.