### PR TITLE
Complete base Home Manager policy

### DIFF
--- a/modules/flake/lib.nix
+++ b/modules/flake/lib.nix
@@ -14,6 +14,9 @@
         in
           assert self.lib.trivial.release == inputs.nixpkgs.lib.trivial.release;
           assert home.home.stateVersion == self.lib.trivial.release;
+          assert home.xdg.enable;
+          assert home.manual.json.enable;
+          assert !home.manual.html.enable;
             home.home.activationPackage;
       })
       (self.lib.mkIf (system == "aarch64-linux") {
@@ -24,6 +27,9 @@
           assert self.lib.trivial.release == inputs.nixpkgs.lib.trivial.release;
           assert cfg.system.stateVersion == self.lib.trivial.release;
           assert home.home.stateVersion == self.lib.trivial.release;
+          assert home.xdg.enable;
+          assert home.manual.json.enable;
+          assert !home.manual.html.enable;
             cfg.system.build.toplevel;
       })
     ];

--- a/modules/profiles/base.nix
+++ b/modules/profiles/base.nix
@@ -16,7 +16,13 @@ in {
             stateVersion = lib.trivial.release;
           };
 
+          manual = {
+            html.enable = false;
+            json.enable = true;
+          };
+
           news.display = "silent";
+          xdg.enable = true;
         }
         (lib.modules.mkIf pkgs.stdenv.hostPlatform.isLinux {
           # FIXME: once intel-media-driver is conditionally included for x86_64-linux,


### PR DESCRIPTION
## What changed

- make the exported Home Manager `base` profile enable XDG
- establish JSON-on / HTML-off manual policy in that profile
- assert the policy through real nixbook-pro and miniboi integrated consumers

## Why

These are coherent foundation defaults and belong in the authoritative Dendritic base profile rather than in the temporary main-branch bridge. The existing interactive default remains unchanged: `base` stays a workable, opinionated profile that consumers may carve down, while an explicit `interactive` profile import remains the strong selection.

## Validation

- complete pre-commit suite
- complete pre-push suite
- evaluated `checks.aarch64-darwin.flake-lib-nixbook-pro.drvPath`
- evaluated `checks.aarch64-linux.flake-lib-miniboi.drvPath`
- confirmed nixbook-pro retains `shell.profiles.interactive.enable = true` and Bash enablement
