### PR TITLE
Deploy exported Home Manager base

### DIFF
--- a/.agents/dendritic/context.md
+++ b/.agents/dendritic/context.md
@@ -19,7 +19,7 @@ operationally frozen Dendritic flake and exposes its module registries beneath
 `self.dendritic`, so
 later slices can port capability cones without rebasing the reconstructed
 branch or deleting unrelated legacy closures. The `dendritic` source is frozen
-at `dc774a7d` and tagged `dendritic-suspended-2026-08-12`; treat it as a
+at `a99ff7e0` and tagged `dendritic-suspended-2026-08-12`; treat it as a
 predecessor/source archive while migration proceeds from current `main`. The
 lock file pins the exact commit; the input URL names the protected branch rather
 than the immutable tag, so branch protection is part of the freeze guarantee.
@@ -298,6 +298,14 @@ replace selections. Do not criticize a profile merely for choosing Bash,
 Helix, FZF, Kitty, or Zen. Do flag a profile if selecting one intended lane
 activates unrelated capabilities or prevents backend substitution.
 
+The exported Home Manager `base` profile intentionally provides interactive
+training wheels: its interactive mode defaults on so the result is immediately
+workable, but a consumer may carve it down with a stronger option definition.
+Explicitly importing the `interactive` profile is the strong symbolic selection
+that turns the same mode on non-defaultly. Capability/interface modules beneath
+these profiles remain independently importable; do not confuse an opinionated
+profile selection with an interface intrinsically enabling its backend.
+
 Keep these categories conceptually distinct:
 
 1. interface modules define vTables/contracts;
@@ -404,16 +412,16 @@ port supersedes it. Do not replace it with `nix flake check`, `nix build
 
 Current durable coordinates as of 2026-08-13:
 
-- frozen predecessor branch: `dendritic` at `dc774a7d` (merged PR #444; its
-  prerequisite coherent-library repair was merged as PR #443);
-- frozen tag: `dendritic-suspended-2026-08-12` at `dc774a7d`;
+- frozen predecessor branch: `dendritic` at `a99ff7e0` (merged PR #446; its
+  coherent-library prerequisites were merged as PRs #443 and #444);
+- frozen tag: `dendritic-suspended-2026-08-12` at `a99ff7e0`;
 - bridge landed on `main`: `c116a095` (source bridge commit `b341ba3c`);
 - current main-based cleanup/migration branch: `drop-colima-lima-stack`, based
   on `main` at `af7a4b8f`; it is the single review unit for the 2026-08-13
   cleanup sequence recorded above;
 - initial cross-platform HM base commit: `7ba2dae3`;
 - the Home Manager input-registry cone remains predecessor-owned; its public
-  path was repaired through PR #435 and subsequently re-frozen at `dc774a7d`;
+  path was repaired through PR #435 and subsequently re-frozen at `a99ff7e0`;
 - the Dendritic branch was reconstructed through roughly one hundred small
   sequential commits, beginning with `Clean everything out` and rebuilding the
   flake and modules from a blank baseline.
@@ -750,11 +758,11 @@ evidence rather than filename inference.
 | HM Agenix module/package | accepted removal | Do not port it in the thin HM slice. RBW remains selected. |
 | Cachix binary-cache policy | accepted omission for thin slice | Main user Nix settings include krad246 Cachix; Dendritic user Nix settings do not. Old broad daemon/cache policy need not block first HM landing. |
 | broad per-user Nix policy | accepted omission for thin slice | Main evaluates many performance, sandbox, retention, timeout, and cache settings; Dendritic HM evaluates only `experimental-features = [nix-command flakes]` through the registry. |
-| input flake registry | architecturally superseded/win; predecessor-owned | Both expose registries. Dendritic replaces old `flake-registry` with the generic configurable input-registry source and locked/unlocked behavior. Preserve that design and repair it at its authoritative source until an intentional ownership-transfer landing. |
+| input flake registry | architecturally superseded/win; bridged from predecessor | Both expose registries. Dendritic replaces old `flake-registry` with the generic configurable input-registry source and locked/unlocked behavior. Main now consumes it through the exported Dendritic `base`/`standalone` profiles rather than reconstructing the cone. |
 | registry filesystem projection | changed, capability available; path repaired | Main installs `~/nix/path/*` links unconditionally via `home-link-registry`. Dendritic has `input-registry.sysroot.install` and optional search-path projection, currently disabled for this consumer. PR #435 repaired its public absolute path from `/Users/krad246/./nix/path` to `/Users/krad246/nix/path` at the authoritative predecessor source. Selection policy remains to decide. |
 | dotfiles link/sync | accepted removal | Do not port the mutable synchronization/link behavior. |
-| XDG | changed | Main evaluates `xdg.enable=true`; Dendritic evaluates false, while both prefer XDG directories. Likely foundation parity item. |
-| manuals | changed | Effective Main: HTML false (Zen override), JSON true. Dendritic: HTML false, JSON false. Decide general HM manual policy independently of browser integration. |
+| XDG | preserved | PR #446 moved `xdg.enable=true` into the authoritative Dendritic `base`; both standalone and integrated bridge consumers now inherit it. |
+| manuals | preserved foundation policy | PR #446 established HTML false and JSON true in Dendritic `base`, independently of browser integration. |
 | state version | version drift | Main evaluates 26.05 and Dendritic 25.11 due branch input eras. Resolve intentionally during port; do not copy one blindly. |
 | Lorri | preserved on Darwin | Disabled in both on this host. Dendritic dev preset enables it only on Linux. |
 | Bash selection | preserved | Bash enabled in both with completion, VTE, and vi mode. |
@@ -1351,13 +1359,19 @@ Before committing:
 ## Immediate next work
 
 1. Finish total behavioral porting of `. #base`, using the program-by-program HM
-   ledger and explicit owner decisions rather than copying legacy bundles.
-2. Keep the evaluated cross-platform base checks meaningful; during this
-   migration, the temporary pre-push hook realizes their exact selected
-   derivation through wrapped Nix while legacy `check-flake` remains intact.
-3. Prove standalone and system-integrated HM consumers, delete legacy
-   `generic-linux`, and carry its intentionally deferred desktop behavior into
-   the explicit follow-on interface agenda.
+   ledger and explicit owner decisions rather than copying legacy bundles. The
+   bridge now consumes the predecessor's exported `base` and `standalone`
+   profiles directly; do not reconstruct their imports locally.
+2. Keep the evaluated cross-platform base checks meaningful. The standalone
+   factory publishes `checks.<system>.home-manager-base` as the pure,
+   deployable per-system activation artifact, while impure
+   `homeConfigurations.base` selects the same factory for
+   `builtins.currentSystem`; their derivations must remain identical on the
+   current system. During this migration, the temporary pre-push hook realizes
+   the exact selected check derivation while legacy `check-flake` remains intact.
+3. Continue proving both standalone and system-integrated HM consumers. Legacy
+   `generic-linux` is deleted; its intentionally deferred desktop behavior
+   remains in the explicit follow-on interface agenda.
 4. Port the Dendritic flake-policy interface, retaining a rich output surface
    while redesigning declaration/ownership/composition semantics.
 5. Continue normalized old/new `nixbook-pro` behavioral diffs, Linux-builder

--- a/.agents/dendritic/manifest
+++ b/.agents/dendritic/manifest
@@ -1,5 +1,5 @@
 format=dendritic-context-v1
-proxy-sha256=fc1afd04ee546fe2b48101bc8f70ebe144d9943f7118c8f9ca34a957f7b26c0e
+proxy-sha256=5eca0a8811955a52218643c79734fb4dd6f31d4ea58b1b1df01cbcf54c86c7cf
 canonical=.agents/dendritic/context.md
 routes=.agents/dendritic/routes.tsv
 generator=.agents/dendritic/context.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This repository is in a long-running Dendritic architecture migration. Do not
 begin architectural work from this compact proxy alone.
 
-Canonical context proxy SHA-256: `fc1afd04ee546fe2b48101bc8f70ebe144d9943f7118c8f9ca34a957f7b26c0e`
+Canonical context proxy SHA-256: `5eca0a8811955a52218643c79734fb4dd6f31d4ea58b1b1df01cbcf54c86c7cf`
 
 Run:
 

--- a/flake.lock
+++ b/flake.lock
@@ -323,11 +323,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786610430,
-        "narHash": "sha256-48GaMsNOYIniVSNAECylU+xAlUCHt8xuP5r9fE01684=",
+        "lastModified": 1786612297,
+        "narHash": "sha256-mxzYBPanVdtFeJLNflAQHWOB7geM9GNZ5YNUdeVt8pM=",
         "owner": "krad246",
         "repo": "nix-systems",
-        "rev": "dc774a7d7995f6df6b0cf7fa5c19749fdf2e666d",
+        "rev": "a99ff7e01bbe4698e1f823094efe82e4b1b4ead0",
         "type": "github"
       },
       "original": {

--- a/flakeModules/dendritic/flake-module.nix
+++ b/flakeModules/dendritic/flake-module.nix
@@ -4,7 +4,15 @@
   lib,
   withSystem,
   ...
-}: {
+}: let
+  homeManagerConfiguration = args:
+    inputs.home-manager.lib.homeManagerConfiguration (
+      args
+      // {
+        modules = [config.flake.dendritic.modules.homeManager.standalone] ++ (args.modules or []);
+      }
+    );
+in {
   options.flake.homeConfigurations = lib.mkOption {
     type = lib.types.lazyAttrsOf lib.types.raw;
     default = {};
@@ -40,93 +48,14 @@
 
     # Stable migration seam. Consumers use this namespace while its values are
     # progressively replaced with modules materialized in the current tree.
-    flake.dendritic = rec {
-      inherit (inputs.dendritic) darwinModules nixosModules;
-
-      modules =
-        inputs.dendritic.modules
-        // {
-          homeManager =
-            inputs.dendritic.modules.homeManager
-            // rec {
-              base = {
-                lib,
-                pkgs,
-                ...
-              }: {
-                imports = [
-                  inputs.dendritic.homeModules.home-manager
-                  inputs.dendritic.homeModules.identity
-                ];
-
-                config = lib.mkMerge [
-                  {
-                    home.preferXdgDirectories = true;
-                    manual = {
-                      html.enable = false;
-                      json.enable = true;
-                    };
-                    news.display = "silent";
-                    xdg.enable = true;
-                  }
-                  (lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
-                    targets.genericLinux = {
-                      enable = true;
-                      gpu.enable = lib.mkDefault false;
-                    };
-
-                    systemd.user.startServices = "sd-switch";
-                  })
-                ];
-              };
-
-              standalone = {
-                config,
-                pkgs,
-                ...
-              }: {
-                imports = [base];
-
-                home = {
-                  username = lib.mkDefault config.identity.person.username;
-                  homeDirectory = lib.mkDefault (
-                    if pkgs.stdenv.hostPlatform.isDarwin
-                    then "/Users/${config.identity.person.username}"
-                    else "/home/${config.identity.person.username}"
-                  );
-                };
-
-                nix.package = lib.mkDefault pkgs.nix;
-              };
-            };
-        };
-
-      homeModules = modules.homeManager;
-
-      homeConfigurations = let
-        inherit (config.flake.dendritic.homeModules) standalone;
-      in {
-        base-aarch64-darwin = inputs.home-manager.lib.homeManagerConfiguration {
-          pkgs = inputs.nixpkgs.legacyPackages.aarch64-darwin;
-          modules = [standalone];
-        };
-
-        base-x86_64-linux = inputs.home-manager.lib.homeManagerConfiguration {
-          pkgs = inputs.nixpkgs.legacyPackages.x86_64-linux;
-          modules = [standalone];
-        };
-      };
+    flake.dendritic = {
+      inherit (inputs.dendritic) darwinModules modules nixosModules;
     };
 
     flake = {
       homeConfigurations = lib.mkIf (!lib.inPureEvalMode) {
-        base = inputs.home-manager.lib.homeManagerConfiguration {
+        base = homeManagerConfiguration {
           pkgs = withSystem builtins.currentSystem ({pkgs, ...}: pkgs);
-          modules = let
-            inherit (config.flake.dendritic.homeModules) standalone;
-          in [
-            standalone
-          ];
         };
       };
 
@@ -147,35 +76,49 @@
       };
     };
 
-    perSystem = {system, ...}:
+    perSystem = {
+      pkgs,
+      system,
+      ...
+    }: let
+      standalone = homeManagerConfiguration {inherit pkgs;};
+      cfg = standalone.config;
+    in
       lib.mkMerge [
+        {
+          checks.home-manager-base = standalone.activationPackage;
+        }
         (lib.mkIf (system == "aarch64-darwin") {
           checks = {
-            dendritic-hm-base = let
-              configuration = config.flake.dendritic.homeConfigurations.base-aarch64-darwin;
-              cfg = configuration.config;
-            in
-              assert cfg.home.username == "krad246";
-              assert cfg.home.homeDirectory == "/Users/krad246";
-              assert cfg.identity.person
-              == {
-                email = "krad246@gmail.com";
-                name = "Keerthi Radhakrishnan";
-                username = "krad246";
-              };
-              assert cfg.home.stateVersion == inputs.nixpkgs.lib.trivial.release;
-              assert cfg.xdg.enable;
-              assert cfg.manual.json.enable;
-              assert !cfg.manual.html.enable;
-              assert cfg.programs.home-manager.enable;
-              assert !cfg.programs.bash.enable;
-              assert !cfg.programs.bat.enable;
-              assert !cfg.programs.fzf.enable;
-              assert !cfg.programs.git.enable;
-              assert !cfg.programs.helix.enable;
-              assert !cfg.programs.kitty.enable;
-              assert !cfg.programs.rbw.enable;
-                configuration.activationPackage;
+            dendritic-hm-base = assert cfg.home.username == "krad246";
+            assert cfg.home.homeDirectory == "/Users/krad246";
+            assert cfg.identity.person
+            == {
+              email = "krad246@gmail.com";
+              name = "Keerthi Radhakrishnan";
+              username = "krad246";
+            };
+            assert cfg.home.stateVersion == inputs.nixpkgs.lib.trivial.release;
+            assert cfg.xdg.enable;
+            assert cfg.manual.json.enable;
+            assert !cfg.manual.html.enable;
+            assert cfg.input-registry.registry.managed;
+            assert !cfg.input-registry.registry.locked;
+            assert !cfg.input-registry.sysroot.install;
+            assert !cfg.input-registry.search-path.enable;
+            assert cfg.nix.registry ? nixpkgs;
+            assert cfg.nix.registry ? home-manager;
+            assert cfg.nix.settings.experimental-features == ["nix-command" "flakes"];
+            assert cfg.programs.home-manager.enable;
+            assert cfg.shell.profiles.interactive.enable;
+            assert cfg.programs.bash.enable;
+            assert cfg.programs.bat.enable;
+            assert cfg.programs.fzf.enable;
+            assert !cfg.programs.git.enable;
+            assert !cfg.programs.helix.enable;
+            assert !cfg.programs.kitty.enable;
+            assert !cfg.programs.rbw.enable;
+              standalone.activationPackage;
 
             dendritic-nixbook-pro-hm = let
               configuration = inputs.dendritic.darwinConfigurations.nixbook-pro;
@@ -186,21 +129,29 @@
               assert home.home.homeDirectory == "/Users/${cfg.owner.username}";
               assert home.home.stateVersion == inputs.nixpkgs.lib.trivial.release;
               assert home.programs.home-manager.enable;
+              assert home.xdg.enable;
+              assert home.manual.json.enable;
+              assert !home.manual.html.enable;
                 home.home.activationPackage;
           };
         })
         (lib.mkIf (system == "x86_64-linux") {
-          checks.dendritic-hm-base = let
-            configuration = config.flake.dendritic.homeConfigurations.base-x86_64-linux;
-            cfg = configuration.config;
-          in
-            assert cfg.home.username == "krad246";
-            assert cfg.home.homeDirectory == "/home/krad246";
-            assert cfg.home.stateVersion == inputs.nixpkgs.lib.trivial.release;
-            assert cfg.targets.genericLinux.enable;
-            assert !cfg.targets.genericLinux.gpu.enable;
-            assert cfg.systemd.user.startServices;
-              configuration.activationPackage;
+          checks.dendritic-hm-base = assert cfg.home.username == "krad246";
+          assert cfg.home.homeDirectory == "/home/krad246";
+          assert cfg.home.stateVersion == inputs.nixpkgs.lib.trivial.release;
+          assert cfg.targets.genericLinux.enable;
+          assert !cfg.targets.genericLinux.gpu.enable;
+          assert cfg.systemd.user.startServices;
+          assert cfg.input-registry.registry.managed;
+          assert !cfg.input-registry.registry.locked;
+          assert !cfg.input-registry.sysroot.install;
+          assert !cfg.input-registry.search-path.enable;
+          assert cfg.nix.registry ? nixpkgs;
+          assert cfg.nix.registry ? home-manager;
+          assert cfg.nix.settings.experimental-features == ["nix-command" "flakes"];
+          assert cfg.shell.profiles.interactive.enable;
+          assert cfg.programs.bash.enable;
+            standalone.activationPackage;
 
           checks.generic-headless-interactive = let
             configuration = config.flake.nixosConfigurations.generic-headless-interactive;


### PR DESCRIPTION
## What changed

- pin the frozen Dendritic predecessor at merged PR #446 (`a99ff7e0`)
- consume its exported Home Manager `base` and `standalone` profiles directly
- replace hard-coded Darwin/Linux configurations with one standalone factory
- publish `packages.<system>.home-manager-base` as the pure deployable activation artifact
- retain impure `homeConfigurations.base` as the current-system convenience view of the same factory
- strengthen base checks around interactive training wheels, registry policy, XDG/manual policy, and still-disabled dev/editor/terminal/secret backends
- synchronize the canonical migration context

## Why

The bridge had begun reconstructing Dendritic profile imports and policy locally. That duplicated the authoritative profile and obscured the distinction between importing a definition into this flake's package fixed point and splicing a realized universe. The corrected bridge imports the exported profile definitions and evaluates them with each `perSystem` package set.

## Validation

- pure Darwin package and impure current-system Home Manager output resolve to the identical activation derivation
- evaluated and realized `packages.aarch64-darwin.home-manager-base`
- evaluated Darwin and x86_64-linux standalone checks
- evaluated the real integrated nixbook-pro HM check
- evaluated the generic headless interactive VM boundary
- complete pre-commit and pre-push suites
- refreshed and verified canonical context plus local mirrors

Full `nix flake show --all-systems` reaches the new artifact on aarch64-darwin, then stops at the existing unrelated `packages.aarch64-linux` use of removed `haskell.packages.ghc964`; that package-lane defect is not introduced by this PR.
